### PR TITLE
fix: removed typo & updated API name

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ class NewRelic {
   * Creates and records a MobileBreadcrumb for Current Screen
   */
   onStateChange = (state) => {
-    var currentScreenName = this.getCurrentScrren(state);
+    var currentScreenName = this.getCurrentScreen(state);
     var params = {
       'screenName': currentScreenName
     };
@@ -109,12 +109,12 @@ class NewRelic {
 
   }
 
-  getCurrentScrren(state) {
+  getCurrentScreen(state) {
 
     if (!state.routes[state.index].state) {
       return state.routes[state.index].name
     }
-    return this.getCurrentScrren(state.routes[state.index].state);
+    return this.getCurrentScreen(state.routes[state.index].state);
   }
 
   /**


### PR DESCRIPTION
Fixed a typo in the API name, changed `getCurrentScrren()` -> `getCurrentScreen()`  