### PR TITLE
test: Add codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,4 @@
-name: Workflow for Codecov example-javascript
+name: Run codecov and upload coverage
 on: [push, pull_request]
 jobs:
   run:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,20 @@
+name: Workflow for Codecov example-javascript
+on: [push, pull_request]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests and collect coverage
+        run: npm run test:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Community Plus header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
+[![npm](https://img.shields.io/npm/v/newrelic-react-native-agent?color=blue)](https://www.npmjs.com/package/newrelic-react-native-agent)
+
 # New Relic React Native Agent
 
 This agent uses native New Relic Android and iOS agents to instrument the React-Native Javascript environment. The New Relic SDKs collect crashes, network traffic, and other information for hybrid apps using native components.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Community Plus header](https://github.com/newrelic/opensource-website/raw/main/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
 [![npm](https://img.shields.io/npm/v/newrelic-react-native-agent?color=blue)](https://www.npmjs.com/package/newrelic-react-native-agent)
+[![codecov](https://codecov.io/github/newrelic/newrelic-react-native-agent/branch/main/graph/badge.svg?token=J597PET0X4)](https://codecov.io/github/newrelic/newrelic-react-native-agent)
 
 # New Relic React Native Agent
 


### PR DESCRIPTION
Adding codecov for code coverage tool.

Reports will compare against `main` once the workflow exists in `main`. The badge will also update with coverage % after it's merged. 