### PR TITLE
Reduce bundle size

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ import { LOG } from './new-relic/nr-logger';
 import { Platform } from 'react-native';
 import NRMAModularAgentWrapper from './new-relic/nrma-modular-agent-wrapper';
 import version from './new-relic/version';
-import * as _ from 'lodash';
+import forEach from 'lodash.foreach';
 
 import {
   getUnhandledPromiseRejectionTracker,
@@ -489,7 +489,7 @@ class NewRelic {
   send(name, args) {
     const nameStr = String(name);
     const argsStr = {};
-    _.forEach(args, (value, key) => {
+    forEach(args, (value, key) => {
       argsStr[String(key)] = String(value);
     });
     this.NRMAModularAgentWrapper.execute('recordCustomEvent', 'consoleEvents', nameStr, argsStr);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "commitizen": "^4.2.4",
     "react-native-promise-rejection-utils": "0.0.1",
     "@expo/config-plugins": "^4.0.14"
   },
@@ -58,6 +57,7 @@
     "aws-sdk": "^2.1048.0",
     "babel-eslint": "^8.2.6",
     "babel-jest": "^24.8.0",
+    "commitizen": "^4.2.4",
     "cz-conventional-changelog": "^3.3.0",
     "docdash": "^1.2.0",
     "edit-json-file": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "react-native-promise-rejection-utils": "0.0.1",
-    "@expo/config-plugins": "^4.0.14"
+    "@expo/config-plugins": "^4.0.14",
+    "lodash.foreach": "^4.5.0",
+    "react-native-promise-rejection-utils": "0.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.16.7",


### PR DESCRIPTION
Thanks for the great library. We are using it in our products.
One thing I did notice was the large bundle size.

Metro does not currently implement tree shaking.Only `lodash.foreach` is used, but all code is bundled.
Changing to `lodash.foreach` will reduce the bundle size.

This change reduces the bundle size by approximately 70 KB.