### PR TITLE
fix: update naming on httpResponseBody

### DIFF
--- a/NewRelicExampleApp/index.js
+++ b/NewRelicExampleApp/index.js
@@ -39,7 +39,7 @@ import {Platform} from 'react-native';
     networkErrorRequestEnabled: true,
 
     // Optional:Enable or disable capture of HTTP response bodies for HTTP error traces, and MobileRequestError events.
-    httpRequestBodyCaptureEnabled: true,
+    httpResponseBodyCaptureEnabled: true,
 
    //Android Specific
    // Optional: Enable or disable agent logging.

--- a/NewRelicExampleApp/screens/Api.js
+++ b/NewRelicExampleApp/screens/Api.js
@@ -27,7 +27,7 @@ const ApiScreen = () => {
   const httpBodyHandler = () => {
     setHttpBodyFlagEnabled(previousState => !previousState);
     // alert(!httpBodyFlagEnabled);
-    NewRelic.httpRequestBodyCaptureEnabled(!httpBodyFlagEnabled);
+    NewRelic.httpResponseBodyCaptureEnabled(!httpBodyFlagEnabled);
   };
 
   const breadcrumbHandler = () => {

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ import {Platform} from 'react-native';
     networkErrorRequestEnabled: true,
 
     // Optional:Enable or disable capture of HTTP response bodies for HTTP error traces, and MobileRequestError events.
-    httpRequestBodyCaptureEnabled: true,
+    httpResponseBodyCaptureEnabled: true,
 
    //Android Specific
    // Optional: Enable or disable agent logging.
@@ -375,10 +375,10 @@ See the examples below, and for more detail, see [New Relic IOS SDK doc](https:/
     NewRelic.networkErrorRequestEnabled(true);
 ```
 
-### [httpRequestBodyCaptureEnabled](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags/#ff-withHttpResponseBodyCaptureEnabled)(enabled: boolean) : void;
+### [httpResponseBodyCaptureEnabled](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/android-agent-configuration-feature-flags/#ff-withHttpResponseBodyCaptureEnabled)(enabled: boolean) : void;
 > Enable or disable capture of HTTP response bodies for HTTP error traces, and MobileRequestError events.
 ```js
-    NewRelic.httpRequestBodyCaptureEnabled(true);
+    NewRelic.httpResponseBodyCaptureEnabled(true);
 ```
 
 ## How to see JSErrors(Fatal/Non Fatal) in NewRelic One?

--- a/__mocks__/nrm-modular-agent.js
+++ b/__mocks__/nrm-modular-agent.js
@@ -8,7 +8,7 @@ export default  {
   analyticsEventEnabled: jest.fn(),
   networkRequestEnabled: jest.fn(),
   networkErrorRequestEnabled: jest.fn(),
-  httpRequestBodyCaptureEnabled: jest.fn(),
+  httpResponseBodyCaptureEnabled: jest.fn(),
   recordBreadcrumb: jest.fn(),
   recordCustomEvent: jest.fn(),
   crashNow: jest.fn(),

--- a/android/src/main/java/com/NewRelic/NRMModularAgentModule.java
+++ b/android/src/main/java/com/NewRelic/NRMModularAgentModule.java
@@ -64,7 +64,7 @@ public class NRMModularAgentModule extends ReactContextBaseJavaModule {
                 NewRelic.disableFeature(FeatureFlag.NetworkErrorRequests);
             }
 
-            if ((Boolean) agentConfig.get("httpRequestBodyCaptureEnabled")) {
+            if ((Boolean) agentConfig.get("httpResponseBodyCaptureEnabled")) {
                 NewRelic.enableFeature(FeatureFlag.HttpResponseBodyCapture);
             } else {
                 NewRelic.disableFeature(FeatureFlag.HttpResponseBodyCapture);
@@ -162,7 +162,7 @@ public class NRMModularAgentModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void httpRequestBodyCaptureEnabled(boolean enabled) {
+    public void httpResponseBodyCaptureEnabled(boolean enabled) {
         if(enabled) {
             NewRelic.enableFeature(FeatureFlag.HttpResponseBodyCapture);
         } else {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ class NewRelic {
       interactionTracingEnabled: true,
       networkRequestEnabled: true,
       networkErrorRequestEnabled: true,
-      httpRequestBodyCaptureEnabled: true,
+      httpResponseBodyCaptureEnabled: true,
       loggingEnabled: true,
       webViewInstrumentation: true
     };
@@ -174,8 +174,8 @@ class NewRelic {
    * Enable or disable capture of HTTP response bodies for HTTP error traces, and MobileRequestError events.
    * @param enabled {boolean} Boolean value for enabling HTTP response bodies.
    */
-  httpRequestBodyCaptureEnabled(enabled) {
-    this.NRMAModularAgentWrapper.execute('httpRequestBodyCaptureEnabled', enabled);
+  httpResponseBodyCaptureEnabled(enabled) {
+    this.NRMAModularAgentWrapper.execute('httpResponseBodyCaptureEnabled', enabled);
   }
   
   /**

--- a/ios/bridge/NRMModularAgent.m
+++ b/ios/bridge/NRMModularAgent.m
@@ -51,7 +51,7 @@ RCT_EXPORT_METHOD(startAgent:(NSString* _Nonnull)appKey agentVersion:(NSString* 
         [NewRelic disableFeatures:NRFeatureFlag_RequestErrorEvents];
     }
     
-    if([[agentConfig objectForKey:@"httpRequestBodyCaptureEnabled"]boolValue] == NO) {
+    if([[agentConfig objectForKey:@"httpResponseBodyCaptureEnabled"]boolValue] == NO) {
         [NewRelic disableFeatures:NRFeatureFlag_HttpResponseBodyCapture];
     }
     if([[agentConfig objectForKey:@"webViewInstrumentationEnabled"]boolValue] == NO) {
@@ -97,7 +97,7 @@ RCT_EXPORT_METHOD(networkErrorRequestEnabled:(BOOL) enabled) {
     }
 }
 
-RCT_EXPORT_METHOD(httpRequestBodyCaptureEnabled:(BOOL) enabled) {
+RCT_EXPORT_METHOD(httpResponseBodyCaptureEnabled:(BOOL) enabled) {
     if(enabled) {
         [NewRelic enableFeatures:NRFeatureFlag_HttpResponseBodyCapture];
     } else {

--- a/jestSetup.js
+++ b/jestSetup.js
@@ -8,7 +8,7 @@ jest.mock('./index.js', () => ({
   analyticsEventEnabled: jest.fn(),
   networkRequestEnabled: jest.fn(),
   networkErrorRequestEnabled: jest.fn(),
-  httpRequestBodyCaptureEnabled: jest.fn(),
+  httpResponseBodyCaptureEnabled: jest.fn(),
   recordBreadcrumb: jest.fn(),
   recordCustomEvent: jest.fn(),
   crashNow: jest.fn(),

--- a/new-relic/__tests__/new-relic.spec.js
+++ b/new-relic/__tests__/new-relic.spec.js
@@ -89,9 +89,9 @@ describe('New Relic', () => {
   });
 
   it('should set the network error request flag', () => {
-    NewRelic.httpRequestBodyCaptureEnabled(true);
-    NewRelic.httpRequestBodyCaptureEnabled(false);
-    expect(MockNRM.httpRequestBodyCaptureEnabled.mock.calls.length).toBe(2);
+    NewRelic.httpResponseBodyCaptureEnabled(true);
+    NewRelic.httpResponseBodyCaptureEnabled(false);
+    expect(MockNRM.httpResponseBodyCaptureEnabled.mock.calls.length).toBe(2);
   });
 
   it('should record a valid breadcrumb', () => {

--- a/new-relic/nrma-modular-agent-wrapper.js
+++ b/new-relic/nrma-modular-agent-wrapper.js
@@ -61,8 +61,8 @@ class NRMAModularAgentWrapper {
     NRMModularAgent.networkErrorRequestEnabled(enabled);
   };
 
-  httpRequestBodyCaptureEnabled = (enabled) => {
-    NRMModularAgent.httpRequestBodyCaptureEnabled(enabled);
+  httpResponseBodyCaptureEnabled = (enabled) => {
+    NRMModularAgent.httpResponseBodyCaptureEnabled(enabled);
   };
 
   recordBreadcrumb = (eventName, attributes) => {


### PR DESCRIPTION
Previous name of `httpRequestBody` was inaccurate as no http request body content is captured. Only encoded http response bodies are captured and the name is changed to reflect that.