### PR TITLE
Fix the absolute pathing for source code that caused the pod hash keep changing.

### DIFF
--- a/newrelic-react-native-agent.podspec
+++ b/newrelic-react-native-agent.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
     :text => File.open('LICENSE') {|io| io.read}
   }
 #   todo: we have to make sure the zip matches this name.
-  s.source         = { :http => 'file:' + __dir__ + '/ios/ios-bridge.zip' }
+  s.source         = { :http => 'file:' + '$PODS_TARGET_SRCROOT/../ios/ios-bridge.zip' }
   s.source_files = "ios/bridge/**/*.{h,m}"
   s.platform     = :ios, '9.0'
   s.requires_arc = true


### PR DESCRIPTION
When we build our app on pipeline after the integration of newrelic-react-native-agent, we got git dirty issue that was caused by the pod hash of newrelic-react-native-agent was changed.
We follow a similar issue (https://github.com/facebook/react-native/issues/31121) and changed the podspec file, the hash doesn't change anymore.