### PR TITLE
feat: add typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,14 +283,14 @@ See the examples below, and for more detail, see [New Relic IOS SDK doc](https:/
      NewRelic.setUserId("RN12934");
   ```
 
-### [recordBreadcrumb](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordbreadcrumb)(name: string, attributes?: {[key: string]: boolean | number | string}): void;
+### [recordBreadcrumb](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordbreadcrumb)(name: string, attributes?: {[key: string]: any}): void;
 > Track app activity/screen that may be helpful for troubleshooting crashes.
 
   ```js
      NewRelic.recordBreadcrumb("shoe", {"shoeColor": "blue","shoesize": 9,"shoeLaces": true});
   ```
 
-### [recordCustomEvent](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordcustomevent-android-sdk-api)(eventType: string, eventName?: string, attributes?: {[key: string]: boolean | number | string}): void;
+### [recordCustomEvent](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordcustomevent-android-sdk-api)(eventType: string, eventName?: string, attributes?: {[key: string]: any}): void;
 > Creates and records a custom event for use in New Relic Insights.
 
   ```js

--- a/index.js
+++ b/index.js
@@ -181,9 +181,10 @@ class NewRelic {
   /**
    * Creates and records a MobileBreadcrumb event
    * @param eventName {string} the name you want to give to the breadcrumb event.
-   * @param attributes {Map<string, string|number>} a map that includes a list of attributes.
+   * @param attributes {Map<string, any>} a map that includes a list of attributes.
    */
   recordBreadcrumb(eventName, attributes) {
+    attributes = attributes instanceof Map ? Object.fromEntries(attributes):attributes;
     this.NRMAModularAgentWrapper.execute('recordBreadcrumb', eventName, attributes);
   }
 
@@ -192,9 +193,10 @@ class NewRelic {
    * The event includes a list of attributes, specified as a map.
    * @param eventType {string} The type of event.
    * @param eventName {string} Use this parameter to name the event.
-   * @param attributes {Map<string, string|number>} A map that includes a list of attributes.
+   * @param attributes {Map<string, any>} A map that includes a list of attributes.
    */
   recordCustomEvent(eventType, eventName, attributes) {
+    attributes = attributes instanceof Map ? Object.fromEntries(attributes):attributes;
     this.NRMAModularAgentWrapper.execute('recordCustomEvent', eventType, eventName, attributes);
   }
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,12 @@
   "name": "newrelic-react-native-agent",
   "version": "0.0.9",
   "description": "A New Relic Mobile Agent for React Native",
-  "main": "index.js",
+  "main": "./index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
+    "build": "npm run clean && tsc",
+    "clean": "rimraf ./dist",
+    "prepack": "npm run build",
     "prepare:ios": "node ./scripts/prepare-ios.js",
     "build:pack-ios-bridge": "./modular-build/utils/pack-ios-bridge.sh",
     "use:npmReadme": "mv 'README.md' 'git.README.md' && mv 'npm.README.md' 'README.md'",
@@ -54,7 +58,7 @@
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/preset-env": "^7.16.7",
     "@types/jest": "^24.9.1",
-    "@types/node": "^17.0.8",
+    "@types/node": "^18.11.18",
     "ansi-regex": ">=5.0.1",
     "aws-sdk": "^2.1048.0",
     "babel-eslint": "^8.2.6",
@@ -76,6 +80,7 @@
     "node-notifier": ">=8.0.1",
     "react-native": "^0.70.6",
     "shelljs": "^0.8.4",
+    "typescript": "^4.9.4",
     "unzipper": "^0.10.11"
   },
   "config": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  // Change this to match your project
+  "include": ["./index.js"],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "dist",
+    // go to js file when using IDE functions like
+    // "Go to Definition" in VSCode
+    "declarationMap": true
+  }
+}


### PR DESCRIPTION
Added typescript support (issue #45)

- Added build script to run typescript compiler that will generate `dist` folder with types for `index.js`
- Added `prepack` to run build on `npm pack` and `npm publish`
- Fixed issue with map type not working with native modules. 