### PR TITLE
feat: Add configuration for collector addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ import {Platform} from 'react-native';
 
     //iOS Specific
     // Optional:Enable/Disable automatic instrumentation of WebViews
-    webViewInstrumentation: true
+    webViewInstrumentation: true,
+
+    // Optional: Set a specific collector address for sending data. Omit this field for default address.
+    collectorAddress: "",
+
+    // Optional: Set a specific crash collector address for sending crashes. Omit this field for default address.
+    crashCollectorAddress: ""
   };
 
 

--- a/android/src/main/java/com/NewRelic/NRMModularAgentModule.java
+++ b/android/src/main/java/com/NewRelic/NRMModularAgentModule.java
@@ -83,6 +83,28 @@ public class NRMModularAgentModule extends ReactContextBaseJavaModule {
             }
 
 
+            boolean useDefaultCollectorAddress =
+                    agentConfig.get("collectorAddress") == null ||
+                    ((String) agentConfig.get("collectorAddress")).isEmpty();
+            boolean useDefaultCrashCollectorAddress =
+                    agentConfig.get("crashCollectorAddress") == null ||
+                    ((String) agentConfig.get("crashCollectorAddress")).isEmpty();
+
+            if(useDefaultCollectorAddress && useDefaultCrashCollectorAddress) {
+                NewRelic.withApplicationToken(appKey)
+                        .withApplicationFramework(ApplicationFramework.ReactNative, agentVersion)
+                        .withLoggingEnabled((Boolean) agentConfig.get("loggingEnabled"))
+                        .start(reactContext);
+            } else {
+                String collectorAddress = useDefaultCollectorAddress ? "mobile-collector.newrelic.com" : (String) agentConfig.get("collectorAddress");
+                String crashCollectorAddress = useDefaultCrashCollectorAddress ? "mobile-crash.newrelic.com" : (String) agentConfig.get("crashCollectorAddress");
+                NewRelic.withApplicationToken(appKey)
+                        .withApplicationFramework(ApplicationFramework.ReactNative, agentVersion)
+                        .withLoggingEnabled((Boolean) agentConfig.get("loggingEnabled"))
+                        .usingCollectorAddress(collectorAddress)
+                        .usingCrashCollectorAddress(crashCollectorAddress)
+                        .start(reactContext);
+            }
             NewRelic.withApplicationToken(appKey)
                     .withApplicationFramework(ApplicationFramework.ReactNative, agentVersion)
                     .withLoggingEnabled((Boolean) agentConfig.get("loggingEnabled"))

--- a/index.js
+++ b/index.js
@@ -40,7 +40,9 @@ class NewRelic {
       networkErrorRequestEnabled: true,
       httpResponseBodyCaptureEnabled: true,
       loggingEnabled: true,
-      webViewInstrumentation: true
+      webViewInstrumentation: true,
+      collectorAddress: "",
+      crashCollectorAddress: "",
     };
   }
 
@@ -151,7 +153,8 @@ class NewRelic {
    * @param enabled {boolean} Boolean value for enabling analytics events.
    */
   analyticsEventEnabled(enabled) {
-      this.NRMAModularAgentWrapper.execute('analyticsEventEnabled', enabled);
+    this.agentConfiguration.analyticsEventEnabled = enabled;
+    this.NRMAModularAgentWrapper.execute('analyticsEventEnabled', enabled);
   }
   
   /**
@@ -159,6 +162,7 @@ class NewRelic {
    * @param enabled {boolean} Boolean value for enabling successful HTTP requests.
    */
   networkRequestEnabled(enabled) {
+    this.agentConfiguration.networkRequestEnabled = enabled;
     this.NRMAModularAgentWrapper.execute('networkRequestEnabled', enabled);
   }
 
@@ -167,6 +171,7 @@ class NewRelic {
    * @param enabled {boolean} Boolean value for enabling network request errors.
    */
   networkErrorRequestEnabled(enabled) {
+    this.agentConfiguration.networkErrorRequestEnabled = enabled;
     this.NRMAModularAgentWrapper.execute('networkErrorRequestEnabled', enabled);
   }
 
@@ -175,6 +180,7 @@ class NewRelic {
    * @param enabled {boolean} Boolean value for enabling HTTP response bodies.
    */
   httpResponseBodyCaptureEnabled(enabled) {
+    this.agentConfiguration.httpResponseBodyCaptureEnabled = enabled;
     this.NRMAModularAgentWrapper.execute('httpResponseBodyCaptureEnabled', enabled);
   }
   

--- a/new-relic/__tests__/new-relic.spec.js
+++ b/new-relic/__tests__/new-relic.spec.js
@@ -70,28 +70,73 @@ describe('New Relic', () => {
     expect(MockNRM.startAgent.mock.calls.length).toBe(6);
   });
 
+  it('should have correct default configuration settings', () => {
+    expect(NewRelic.agentConfiguration.analyticsEventEnabled).toBe(true);
+    expect(NewRelic.agentConfiguration.crashReportingEnabled).toBe(true);
+    expect(NewRelic.agentConfiguration.interactionTracingEnabled).toBe(true);
+    expect(NewRelic.agentConfiguration.networkRequestEnabled).toBe(true);
+    expect(NewRelic.agentConfiguration.networkErrorRequestEnabled).toBe(true);
+    expect(NewRelic.agentConfiguration.httpResponseBodyCaptureEnabled).toBe(true);
+    expect(NewRelic.agentConfiguration.loggingEnabled).toBe(true);
+    expect(NewRelic.agentConfiguration.webViewInstrumentation).toBe(true);
+    expect(NewRelic.agentConfiguration.collectorAddress).toBe("");
+    expect(NewRelic.agentConfiguration.crashCollectorAddress).toBe("");
+  });
+
+  it('should change default agent configuration when configuration is passed into the start call', () => {
+    const customerConfiguration = {
+      analyticsEventEnabled: false,
+      crashReportingEnabled: false,
+      interactionTracingEnabled: false,
+      networkRequestEnabled: false,
+      networkErrorRequestEnabled: false,
+      httpResponseBodyCaptureEnabled: false,
+      loggingEnabled: false,
+      webViewInstrumentation: false,
+      collectorAddress: "gov-mobile-collector.newrelic.com",
+      crashCollectorAddress: "gov-mobile-crash.newrelic.com"
+    };
+
+    NewRelic.startAgent("12345", customerConfiguration);
+
+    expect(NewRelic.agentConfiguration.analyticsEventEnabled).toBe(false);
+    expect(NewRelic.agentConfiguration.crashReportingEnabled).toBe(false);
+    expect(NewRelic.agentConfiguration.interactionTracingEnabled).toBe(false);
+    expect(NewRelic.agentConfiguration.networkRequestEnabled).toBe(false);
+    expect(NewRelic.agentConfiguration.networkErrorRequestEnabled).toBe(false);
+    expect(NewRelic.agentConfiguration.httpResponseBodyCaptureEnabled).toBe(false);
+    expect(NewRelic.agentConfiguration.loggingEnabled).toBe(false);
+    expect(NewRelic.agentConfiguration.webViewInstrumentation).toBe(false);
+    expect(NewRelic.agentConfiguration.collectorAddress).toBe("gov-mobile-collector.newrelic.com");
+    expect(NewRelic.agentConfiguration.crashCollectorAddress).toBe("gov-mobile-crash.newrelic.com");
+  });
+
   it('should set the analytics event flag', () => {
     NewRelic.analyticsEventEnabled(true);
     NewRelic.analyticsEventEnabled(false);
     expect(MockNRM.analyticsEventEnabled.mock.calls.length).toBe(2);
+    expect(NewRelic.agentConfiguration.analyticsEventEnabled).toBe(false);
   });
 
   it('should set the network request flag', () => {
     NewRelic.networkRequestEnabled(true);
     NewRelic.networkRequestEnabled(false);
     expect(MockNRM.networkRequestEnabled.mock.calls.length).toBe(2);
+    expect(NewRelic.agentConfiguration.networkRequestEnabled).toBe(false);
   });
 
   it('should set the network error request flag', () => {
     NewRelic.networkErrorRequestEnabled(true);
     NewRelic.networkErrorRequestEnabled(false);
     expect(MockNRM.networkErrorRequestEnabled.mock.calls.length).toBe(2);
+    expect(NewRelic.agentConfiguration.networkErrorRequestEnabled).toBe(false);
   });
 
-  it('should set the network error request flag', () => {
+  it('should set the http response body flag', () => {
     NewRelic.httpResponseBodyCaptureEnabled(true);
     NewRelic.httpResponseBodyCaptureEnabled(false);
     expect(MockNRM.httpResponseBodyCaptureEnabled.mock.calls.length).toBe(2);
+    expect(NewRelic.agentConfiguration.httpResponseBodyCaptureEnabled).toBe(false);
   });
 
   it('should record a valid breadcrumb', () => {
@@ -333,17 +378,19 @@ describe('New Relic', () => {
   });
 
   it('sends console.log to record custom Events', () => {
+    // Each agent start call is 2 custom event calls (5 actual calls prior to this test) = 10
     NewRelic.startAgent("12345");
     console.log('hello');
-    expect(MockNRM.recordCustomEvent.mock.calls.length).toBe(12);
+    expect(MockNRM.recordCustomEvent.mock.calls.length).toBe(15);
   });
 
   it('sends console.warn to record custom Events', () => {
+    // Each agent start call is 2 custom event calls (12 actual calls prior to this test) + 1 console log test = 25 
     NewRelic.startAgent("12345");
     console.log('hello');
     console.warn('hello');
     console.error('hello');
-    expect(MockNRM.recordCustomEvent.mock.calls.length).toBe(25);
+    expect(MockNRM.recordCustomEvent.mock.calls.length).toBe(30);
   });
 
   it('sends breadcrumb for navigation if it is not first screen', () => {


### PR DESCRIPTION
- Added ability to set agent collector addresses (for use on start only). This field defaults to `""`, which will use our default collector address. 
- Updates agentConfiguration when a flag is changed via static method call