### PR TITLE
fix: Check for null error in unhandled promise rejection

### DIFF
--- a/index.js
+++ b/index.js
@@ -461,13 +461,16 @@ class NewRelic {
 
     if (!this.state.didAddPromiseRejection) {
       setUnhandledPromiseRejectionTracker((id, error) => {
-
-        this.NRMAModularAgentWrapper.execute('recordStack',
-          error.name,
-          error.message,
-          error.stack,
-          false,
-          this.JSAppVersion);
+        if(error != undefined) {
+          this.NRMAModularAgentWrapper.execute('recordStack',
+            error.name,
+            error.message,
+            error.stack,
+            false,
+            this.JSAppVersion);
+        } else {
+          this.recordBreadcrumb("Possible Unhandled Promise Rejection", {id: id})
+        }
 
         if (prevTracker !== undefined) {
           prevTracker(id, error)


### PR DESCRIPTION
React Native promise will sometimes give a null error in their promise rejection. This is a fix to handle this case.