### PR TITLE
fix: Console log stringify to JSON now handles cyclical structures

### DIFF
--- a/index.js
+++ b/index.js
@@ -507,11 +507,23 @@ class NewRelic {
   }
 
   sendConsole(type, args) {
-    const argsStr = JSON.stringify(args);
+
+    // Remove circular structures from the args so we can convert to JSON
+    const getCircularReplacer = () => {
+      const seen = new WeakSet();
+      return (key, value) => {
+        if (typeof value === "object" && value !== null) {
+          if (seen.has(value)) {
+            return;
+          }
+          seen.add(value);
+        }
+        return value;
+      };
+    };
+    
+    const argsStr = JSON.stringify(args, getCircularReplacer());
     this.send('JSConsole', { consoleType: type, args: argsStr });
-    // if (type === 'error') {
-    //   this.NRMAModularAgentWrapper.execute('consoleEvents','[JSConsole:Error] ' + argsStr); 
-    // }
   }
 
   send(name, args) {


### PR DESCRIPTION
When we send a log as a custom event, the `JSON.stringify` method will throw an error if the arguments given are a cylical structure. So, we add a replacer to the `JSON.stringify` method using the recommended practice by the MDN docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#circular_references.

However, this will remove all repeating values instead of only circular values. 