### PR TITLE
fix: Add circular structure reference in consoleEvents rather than delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ import { Platform } from 'react-native';
 import NRMAModularAgentWrapper from './new-relic/nrma-modular-agent-wrapper';
 import version from './new-relic/version';
 import forEach from 'lodash.foreach';
+import decycle from './new-relic/cycle';
 
 import {
   getUnhandledPromiseRejectionTracker,
@@ -507,22 +508,7 @@ class NewRelic {
   }
 
   sendConsole(type, args) {
-
-    // Remove circular structures from the args so we can convert to JSON
-    const getCircularReplacer = () => {
-      const seen = new WeakSet();
-      return (key, value) => {
-        if (typeof value === "object" && value !== null) {
-          if (seen.has(value)) {
-            return;
-          }
-          seen.add(value);
-        }
-        return value;
-      };
-    };
-    
-    const argsStr = JSON.stringify(args, getCircularReplacer());
+    const argsStr = JSON.stringify(JSON.decycle(args));
     this.send('JSConsole', { consoleType: type, args: argsStr });
   }
 

--- a/new-relic/__tests__/cycle.spec.js
+++ b/new-relic/__tests__/cycle.spec.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 
+ */
+
+import decycle from '../cycle';
+
+describe('JSON stringify decycle', () => {
+
+  it('should decycle circular structures for stringify', () => {
+    function CircularCreator() {
+      this.abc = "Hello";
+      this.circular = this;
+      this.circular2 = this;
+      this.test = "world";
+      this.num = 123;
+      this.bool = false;
+      this.xyz = "Hello";
+    }
+    
+    const circular = new CircularCreator();
+    expect(function() { JSON.stringify(circular) }).toThrowError(TypeError);
+    expect(function() { JSON.stringify(JSON.decycle(circular)) }).not.toThrowError();
+
+    let jsonStr = JSON.stringify(JSON.decycle(circular));
+
+    expect(jsonStr).toContain("ref");
+    expect(jsonStr).toContain("\"abc\":\"Hello\"");
+    expect(jsonStr).toContain("\"test\":\"world\"");
+    expect(jsonStr).toContain("\"num\":123");
+    expect(jsonStr).toContain("\"bool\":false");
+    expect(jsonStr).toContain("\"xyz\":\"Hello\"");
+  });
+
+  it('should work for non-cyclical objects', () => {
+    let obj = {
+      abc: 123,
+      def: false,
+      ghi: 'testing crockford decycle'
+    }
+
+    expect(function() { JSON.stringify(obj) }).not.toThrowError();
+    expect(function() {JSON.stringify(JSON.decycle(obj))} ).not.toThrowError();
+    expect(JSON.stringify(JSON.decycle(obj))).toContain("\"abc\":123");
+    expect(JSON.stringify(JSON.decycle(obj))).toContain("\"def\":false");
+    expect(JSON.stringify(JSON.decycle(obj))).toContain("\"ghi\":\"testing crockford decycle\"");
+
+  });
+
+  it('should work for arrays', () => {
+    let arr = [];
+    let prev = null;
+    for(var i = 0; i < 10; ++i) {
+      prev = arr[i] =  {
+        prev: prev
+      }
+    }
+    arr[0].prev = arr[9];
+
+    expect(function() { JSON.stringify(arr) }).toThrowError();
+    expect(function() { JSON.stringify(JSON.decycle(arr))}).not.toThrowError();
+    expect(JSON.stringify(JSON.decycle(arr))).toContain("ref");
+  });
+
+});

--- a/new-relic/cycle.js
+++ b/new-relic/cycle.js
@@ -1,0 +1,114 @@
+/*
+    cycle.js
+    2021-05-31
+    Public Domain.
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+    This code should be minified before deployment.
+    See https://www.crockford.com/jsmin.html
+    USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+    NOT CONTROL.
+*/
+
+// The file uses the WeakMap feature of ES6.
+
+/*jslint eval */
+
+/*property
+    $ref, decycle, forEach, get, indexOf, isArray, keys, length, push,
+    retrocycle, set, stringify, test
+*/
+
+if (typeof JSON.decycle !== "function") {
+  JSON.decycle = function decycle(object, replacer) {
+      "use strict";
+
+// Make a deep copy of an object or array, assuring that there is at most
+// one instance of each object or array in the resulting structure. The
+// duplicate references (which might be forming cycles) are replaced with
+// an object of the form
+
+//      {"$ref": PATH}
+
+// where the PATH is a JSONPath string that locates the first occurance.
+
+// So,
+
+//      var a = [];
+//      a[0] = a;
+//      return JSON.stringify(JSON.decycle(a));
+
+// produces the string '[{"$ref":"$"}]'.
+
+// If a replacer function is provided, then it will be called for each value.
+// A replacer function receives a value and returns a replacement value.
+
+// JSONPath is used to locate the unique object. $ indicates the top level of
+// the object or array. [NUMBER] or [STRING] indicates a child element or
+// property.
+
+      var objects = new WeakMap();     // object to path mappings
+
+      return (function derez(value, path) {
+
+// The derez function recurses through the object, producing the deep copy.
+
+          var old_path;   // The path of an earlier occurance of value
+          var nu;         // The new object or array
+
+// If a replacer function was provided, then call it to get a replacement value.
+
+        //   if (replacer !== undefined) {
+        //       value = replacer(value);
+        //   }
+
+// typeof null === "object", so go on if this value is really an object but not
+// one of the weird builtin objects.
+
+          if (
+              typeof value === "object"
+              && value !== null
+              && !(value instanceof Boolean)
+              && !(value instanceof Date)
+              && !(value instanceof Number)
+              && !(value instanceof RegExp)
+              && !(value instanceof String)
+          ) {
+
+// If the value is an object or array, look to see if we have already
+// encountered it. If so, return a {"$ref":PATH} object. This uses an
+// ES6 WeakMap.
+
+              old_path = objects.get(value);
+              if (old_path !== undefined) {
+                  return {$ref: old_path};
+              }
+
+// Otherwise, accumulate the unique value and its path.
+
+              objects.set(value, path);
+
+// If it is an array, replicate the array.
+
+              if (Array.isArray(value)) {
+                  nu = [];
+                  value.forEach(function (element, i) {
+                      nu[i] = derez(element, path + "[" + i + "]");
+                  });
+              } else {
+
+// If it is an object, replicate the object.
+
+                  nu = {};
+                  Object.keys(value).forEach(function (name) {
+                      nu[name] = derez(
+                          value[name],
+                          path + "[" + JSON.stringify(name) + "]"
+                      );
+                  });
+              }
+              return nu;
+          }
+          return value;
+      }(object, "$"));
+  };
+}


### PR DESCRIPTION
Updating PR #65 to now include circular references in `JSON.stringify` by decycling structures. Code to decycle structures taken from Douglas Crockford's decycle: https://github.com/douglascrockford/JSON-js.

- Cyclical objects will no longer be removed and will be replaced by `$ref: PATH`