### PR TITLE
Update for agent configuration on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,21 @@ import {Platform} from 'react-native';
     // Optional:Enable or disable capture of HTTP response bodies for HTTP error traces, and MobileRequestError events.
     httpResponseBodyCaptureEnabled: true,
 
-   //Android Specific
-   // Optional: Enable or disable agent logging.
+    // Optional:Enable or disable agent logging.
     loggingEnabled: true,
 
-    //iOS Specific
+    // Optional:Specifies the log level. Omit this field for the default log level.
+    // Options include: ERROR (least verbose), WARNING, INFO, VERBOSE, AUDIT (most verbose).
+    logLevel: "INFO",
+
+    // iOS Specific
     // Optional:Enable/Disable automatic instrumentation of WebViews
     webViewInstrumentation: true,
 
-    // Optional: Set a specific collector address for sending data. Omit this field for default address.
+    // Optional:Set a specific collector address for sending data. Omit this field for default address.
     collectorAddress: "",
 
-    // Optional: Set a specific crash collector address for sending crashes. Omit this field for default address.
+    // Optional:Set a specific crash collector address for sending crashes. Omit this field for default address.
     crashCollectorAddress: ""
   };
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ import {Platform} from 'react-native';
 
     // Optional:Specifies the log level. Omit this field for the default log level.
     // Options include: ERROR (least verbose), WARNING, INFO, VERBOSE, AUDIT (most verbose).
-    logLevel: "INFO",
+    logLevel: NewRelic.LogLevel.INFO,
 
     // iOS Specific
     // Optional:Enable/Disable automatic instrumentation of WebViews
@@ -328,17 +328,17 @@ See the examples below, and for more detail, see [New Relic IOS SDK doc](https:/
 ```
 
 ### (DEPRECATED) [noticeNetworkFailure](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/notice-network-failure)(url: string, httpMethod: string, startTime: number, endTime: number, failure: string): void; 
-> (This method is now deprecated. Use noticeHttpTransaction instead.) Records network failures. If a network request fails, use this method to record details about the failures. In most cases, place this call inside exception handlers, such as catch blocks. Supported failures are: `Unknown`, `BadURL`, `TimedOut`, `CannotConnectToHost`, `DNSLookupFailed`, `BadServerResponse`, `SecureConnectionFailed`.
+> (This method is now deprecated. Use noticeHttpTransaction instead.) Records network failures. If a network request fails, use this method to record details about the failures. In most cases, place this call inside exception handlers, such as catch blocks.
 ```js
-    NewRelic.noticeNetworkFailure('https://github.com', 'GET', Date.now(), Date.now(), 'BadURL');
+    NewRelic.noticeNetworkFailure('https://github.com', 'GET', Date.now(), Date.now(), NewRelic.NetworkFailure.BadURL);
 ```
 
 ### [recordMetric](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordmetric-android-sdk-api)(name: string, category: string, value?: number, countUnit?: string, valueUnit?: string): void;
-> Records custom metrics (arbitrary numerical data), where countUnit is the measurement unit of the metric count and valueUnit is the measurement unit for the metric value. If using countUnit or valueUnit, then all of value, countUnit, and valueUnit must all be set. Supported measurements for countUnit and valueUnit are: `PERCENT`, `BYTES`, `SECONDS`, `BYTES_PER_SECOND`, `OPERATIONS`
+> Records custom metrics (arbitrary numerical data), where countUnit is the measurement unit of the metric count and valueUnit is the measurement unit for the metric value. If using countUnit or valueUnit, then all of value, countUnit, and valueUnit must all be set.
 ```js
     NewRelic.recordMetric('RNCustomMetricName', 'RNCustomMetricCategory');
     NewRelic.recordMetric('RNCustomMetricName', 'RNCustomMetricCategory', 12);
-    NewRelic.recordMetric('RNCustomMetricName', 'RNCustomMetricCategory', 13, 'PERCENT', 'SECONDS');
+    NewRelic.recordMetric('RNCustomMetricName', 'RNCustomMetricCategory', 13, NewRelic.MetricUnit.PERCENT, NewRelic.MetricUnit.SECONDS);
 ```
 
 ### [removeAllAttributes](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/remove-all-attributes)(): void;

--- a/android/src/main/java/com/NewRelic/NRMModularAgentModule.java
+++ b/android/src/main/java/com/NewRelic/NRMModularAgentModule.java
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.Callback;
 import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.NewRelic;
 import com.newrelic.agent.android.ApplicationFramework;
+import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.metric.MetricUnit;
 import com.newrelic.agent.android.util.NetworkFailure;
@@ -82,6 +83,24 @@ public class NRMModularAgentModule extends ReactContextBaseJavaModule {
                 NewRelic.disableFeature(FeatureFlag.InteractionTracing);
             }
 
+            Map<String, Integer> strToLogLevel = new HashMap<>();
+            strToLogLevel.put("ERROR", AgentLog.ERROR);
+            strToLogLevel.put("WARNING", AgentLog.WARNING);
+            strToLogLevel.put("INFO", AgentLog.INFO);
+            strToLogLevel.put("VERBOSE", AgentLog.VERBOSE);
+            strToLogLevel.put("AUDIT", AgentLog.AUDIT);
+
+            // INFO is default log level
+            int logLevel = AgentLog.INFO;
+            if (agentConfig.get("logLevel") != null) {
+                String configLogLevel = (String) agentConfig.get("logLevel");
+                if(configLogLevel != null) {
+                    configLogLevel = configLogLevel.toUpperCase();
+                    if(strToLogLevel.containsKey(configLogLevel)) {
+                        logLevel = strToLogLevel.get(configLogLevel);
+                    }
+                }
+            }
 
             boolean useDefaultCollectorAddress =
                     agentConfig.get("collectorAddress") == null ||
@@ -94,6 +113,7 @@ public class NRMModularAgentModule extends ReactContextBaseJavaModule {
                 NewRelic.withApplicationToken(appKey)
                         .withApplicationFramework(ApplicationFramework.ReactNative, agentVersion)
                         .withLoggingEnabled((Boolean) agentConfig.get("loggingEnabled"))
+                        .withLogLevel(logLevel)
                         .start(reactContext);
             } else {
                 String collectorAddress = useDefaultCollectorAddress ? "mobile-collector.newrelic.com" : (String) agentConfig.get("collectorAddress");
@@ -101,14 +121,11 @@ public class NRMModularAgentModule extends ReactContextBaseJavaModule {
                 NewRelic.withApplicationToken(appKey)
                         .withApplicationFramework(ApplicationFramework.ReactNative, agentVersion)
                         .withLoggingEnabled((Boolean) agentConfig.get("loggingEnabled"))
+                        .withLogLevel(logLevel)
                         .usingCollectorAddress(collectorAddress)
                         .usingCrashCollectorAddress(crashCollectorAddress)
                         .start(reactContext);
             }
-            NewRelic.withApplicationToken(appKey)
-                    .withApplicationFramework(ApplicationFramework.ReactNative, agentVersion)
-                    .withLoggingEnabled((Boolean) agentConfig.get("loggingEnabled"))
-                    .start(reactContext);
 
             NewRelic.setAttribute("React Native Version", reactNativeVersion);
             StatsEngine.get().inc("Supportability/Mobile/Android/ReactNative/Agent/" + agentVersion);

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ class NewRelic {
       networkErrorRequestEnabled: true,
       httpResponseBodyCaptureEnabled: true,
       loggingEnabled: true,
+      logLevel: "INFO",
       webViewInstrumentation: true,
       collectorAddress: "",
       crashCollectorAddress: "",

--- a/index.js
+++ b/index.js
@@ -41,11 +41,38 @@ class NewRelic {
       networkErrorRequestEnabled: true,
       httpResponseBodyCaptureEnabled: true,
       loggingEnabled: true,
-      logLevel: "INFO",
+      logLevel: this.LogLevel.INFO,
       webViewInstrumentation: true,
       collectorAddress: "",
       crashCollectorAddress: "",
     };
+  }
+
+  LogLevel = {
+    // ERROR is least verbose and AUDIT is most verbose
+    ERROR: "ERROR",
+    WARNING: "WARNING",
+    INFO: "INFO",
+    VERBOSE: "VERBOSE",
+    AUDIT: "AUDIT"
+  };
+
+  NetworkFailure = {
+    Unknown: 'Unknown',
+    BadURL: 'BadURL',
+    TimedOut: 'TimedOut',
+    CannotConnectToHost: 'CannotConnectToHost', 
+    DNSLookupFailed: 'DNSLookupFailed',
+    BadServerResponse: 'BadServerResponse',
+    SecureConnectionFailed: 'SecureConnectionFailed'
+  }
+
+  MetricUnit = {
+    PERCENT: 'PERCENT',
+    BYTES: 'BYTES',
+    SECONDS: 'SECONDS', 
+    BYTES_PER_SECOND: 'BYTES_PER_SECOND',
+    OPERATIONS: 'OPERATIONS'
   }
 
   /**
@@ -250,7 +277,7 @@ class NewRelic {
    * @param httpMethod {string} The HTTP method used, such as GET or POST.
    * @param startTime {number} The start time of the request in milliseconds since the epoch.
    * @param endTime {number} The end time of the request in milliseconds since the epoch.
-   * @param failure {string} Name of the network failure. Possible values are 'Unknown', 'BadURL', 'TimedOut', 'CannotConnectToHost', 'DNSLookupFailed', 'BadServerResponse', 'SecureConnectionFailed'.
+   * @param failure {string} Name of the network failure. Possible values are in NewRelic.NetworkFailure.
    */
   noticeNetworkFailure(url, httpMethod, startTime, endTime, failure) {
     this.NRMAModularAgentWrapper.execute('noticeNetworkFailure', url, httpMethod, startTime, endTime, failure);
@@ -261,8 +288,8 @@ class NewRelic {
    * @param name {string} The name for the custom metric.
    * @param category {string} The metric category name. 
    * @param value {number} Optional. The value of the metric. Value should be a non-zero positive number. 
-   * @param countUnit {string} Optional (but requires value and valueUnit to be set). Unit of measurement for the metric count. Supported values are 'PERCENT', 'BYTES', 'SECONDS', 'BYTES_PER_SECOND', or 'OPERATIONS'.
-   * @param valueUnit {string} Optional (but requires value and countUnit to be set). Unit of measurement for the metric value. Supported values are 'PERCENT', 'BYTES', 'SECONDS', 'BYTES_PER_SECOND', or 'OPERATIONS'. 
+   * @param countUnit {string} Optional (but requires value and valueUnit to be set). Unit of measurement for the metric count. Supported values are in NewRelic.MetricUnit.
+   * @param valueUnit {string} Optional (but requires value and countUnit to be set). Unit of measurement for the metric value. Supported values are in NewRelic.MetricUnit. 
    */
   recordMetric(name, category, value=-1, countUnit=null, valueUnit=null) {
     this.NRMAModularAgentWrapper.execute('recordMetric', name, category, value, countUnit, valueUnit);

--- a/ios/bridge/NRMModularAgent.m
+++ b/ios/bridge/NRMModularAgent.m
@@ -54,7 +54,7 @@ RCT_EXPORT_METHOD(startAgent:(NSString* _Nonnull)appKey agentVersion:(NSString* 
     if([[agentConfig objectForKey:@"httpResponseBodyCaptureEnabled"]boolValue] == NO) {
         [NewRelic disableFeatures:NRFeatureFlag_HttpResponseBodyCapture];
     }
-    if([[agentConfig objectForKey:@"webViewInstrumentationEnabled"]boolValue] == NO) {
+    if([[agentConfig objectForKey:@"webViewInstrumentation"]boolValue] == NO) {
         [NewRelic disableFeatures:NRFeatureFlag_WebViewInstrumentation];
     }
     

--- a/ios/bridge/NRMModularAgent.m
+++ b/ios/bridge/NRMModularAgent.m
@@ -62,6 +62,34 @@ RCT_EXPORT_METHOD(startAgent:(NSString* _Nonnull)appKey agentVersion:(NSString* 
         [NewRelic disableFeatures:NRFeatureFlag_InteractionTracing];
     }
     
+    //Default is NRLogLevelWarning
+    NRLogLevels logLevel = NRLogLevelWarning;
+    NSDictionary *logDict = @{
+        @"ERROR": [NSNumber numberWithInt:NRLogLevelError],
+        @"WARNING": [NSNumber numberWithInt:NRLogLevelWarning],
+        @"INFO": [NSNumber numberWithInt:NRLogLevelInfo],
+        @"VERBOSE": [NSNumber numberWithInt:NRLogLevelVerbose],
+        @"AUDIT": [NSNumber numberWithInt:NRLogLevelAudit],
+    };
+
+    
+    if ([[agentConfig objectForKey:@"logLevel"] length] != 0) {
+        NSString* configLogLevel = [agentConfig objectForKey:@"logLevel"];
+        if(configLogLevel != nil) {
+            configLogLevel = [configLogLevel uppercaseString];
+            NSNumber* newLogLevel = [logDict valueForKey:configLogLevel];
+            if(newLogLevel != nil) {
+                logLevel = [newLogLevel intValue];
+            }
+        }
+    }
+    
+    if([[agentConfig objectForKey:@"loggingEnabled"]boolValue] == NO) {
+        logLevel = NRLogLevelNone;
+    }
+    
+    [NRLogger setLogLevels:logLevel];
+    
     BOOL useDefaultCollectorAddress = [[agentConfig objectForKey:@"collectorAddress"] length] == 0;
     BOOL useDefaultCrashCollectorAddress = [[agentConfig objectForKey:@"crashCollectorAddress"] length] == 0;
     

--- a/new-relic/__tests__/new-relic.spec.js
+++ b/new-relic/__tests__/new-relic.spec.js
@@ -78,6 +78,7 @@ describe('New Relic', () => {
     expect(NewRelic.agentConfiguration.networkErrorRequestEnabled).toBe(true);
     expect(NewRelic.agentConfiguration.httpResponseBodyCaptureEnabled).toBe(true);
     expect(NewRelic.agentConfiguration.loggingEnabled).toBe(true);
+    expect(NewRelic.agentConfiguration.logLevel).toBe("INFO");
     expect(NewRelic.agentConfiguration.webViewInstrumentation).toBe(true);
     expect(NewRelic.agentConfiguration.collectorAddress).toBe("");
     expect(NewRelic.agentConfiguration.crashCollectorAddress).toBe("");
@@ -92,6 +93,7 @@ describe('New Relic', () => {
       networkErrorRequestEnabled: false,
       httpResponseBodyCaptureEnabled: false,
       loggingEnabled: false,
+      logLevel: "AUDIT",
       webViewInstrumentation: false,
       collectorAddress: "gov-mobile-collector.newrelic.com",
       crashCollectorAddress: "gov-mobile-crash.newrelic.com"
@@ -106,6 +108,7 @@ describe('New Relic', () => {
     expect(NewRelic.agentConfiguration.networkErrorRequestEnabled).toBe(false);
     expect(NewRelic.agentConfiguration.httpResponseBodyCaptureEnabled).toBe(false);
     expect(NewRelic.agentConfiguration.loggingEnabled).toBe(false);
+    expect(NewRelic.agentConfiguration.logLevel).toBe("AUDIT");
     expect(NewRelic.agentConfiguration.webViewInstrumentation).toBe(false);
     expect(NewRelic.agentConfiguration.collectorAddress).toBe("gov-mobile-collector.newrelic.com");
     expect(NewRelic.agentConfiguration.crashCollectorAddress).toBe("gov-mobile-crash.newrelic.com");

--- a/new-relic/__tests__/new-relic.spec.js
+++ b/new-relic/__tests__/new-relic.spec.js
@@ -78,7 +78,7 @@ describe('New Relic', () => {
     expect(NewRelic.agentConfiguration.networkErrorRequestEnabled).toBe(true);
     expect(NewRelic.agentConfiguration.httpResponseBodyCaptureEnabled).toBe(true);
     expect(NewRelic.agentConfiguration.loggingEnabled).toBe(true);
-    expect(NewRelic.agentConfiguration.logLevel).toBe("INFO");
+    expect(NewRelic.agentConfiguration.logLevel).toBe(NewRelic.LogLevel.INFO);
     expect(NewRelic.agentConfiguration.webViewInstrumentation).toBe(true);
     expect(NewRelic.agentConfiguration.collectorAddress).toBe("");
     expect(NewRelic.agentConfiguration.crashCollectorAddress).toBe("");
@@ -199,12 +199,12 @@ describe('New Relic', () => {
   });
 
   it('should notice network failure with correct params', () => {
-    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), 'Unknown');
-    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), 'BadURL');
-    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), 'CannotConnectToHost');
-    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), 'DNSLookupFailed');
-    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), 'BadServerResponse');
-    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), 'SecureConnectionFailed');
+    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), NewRelic.NetworkFailure.Unknown);
+    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), NewRelic.NetworkFailure.BadURL);
+    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), NewRelic.NetworkFailure.CannotConnectToHost);
+    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), NewRelic.NetworkFailure.DNSLookupFailed);
+    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), NewRelic.NetworkFailure.BadServerResponse);
+    NewRelic.noticeNetworkFailure("https://newrelic.com", "POST", Date.now(), Date.now(), NewRelic.NetworkFailure.SecureConnectionFailed);
     expect(MockNRM.noticeNetworkFailure.mock.calls.length).toBe(6);
   });
 
@@ -216,18 +216,18 @@ describe('New Relic', () => {
 
   it('should record metric with correct params', () => {
     NewRelic.recordMetric('fakeName', 'fakeCategory');
-    NewRelic.recordMetric('fakeName', 'fakeCategory', 13);
-    NewRelic.recordMetric('fakeName', 'fakeCategory', 21, 'PERCENT', 'SECONDS');
+    NewRelic.recordMetric('fakeName', 'fakeCategory', 13)
+    NewRelic.recordMetric('fakeName', 'fakeCategory', 21, NewRelic.MetricUnit.PERCENT, NewRelic.MetricUnit.SECONDS);
     expect(MockNRM.recordMetric.mock.calls.length).toBe(3);
   });
 
   it('should not record metric with bad params', () => {
-    NewRelic.recordMetric('fakeName', 'fakeCategory', 2, 'SECONDS');
-    NewRelic.recordMetric('fakeName', 'fakeCategory', -1, 'SECONDS', 'PERCENT');
-    NewRelic.recordMetric('fakeName', 'fakeCategory', 10, null, 'BYTES_PER_SECOND');
-    NewRelic.recordMetric('fakeName', 'fakeCategory', 3, 'MINUTES', 'SECONDS');
-    NewRelic.recordMetric('fakeName', 'fakeCategory', 3, 'PERCENT', 'HOURS');
-    NewRelic.recordMetric('fakeName', 'fakeCategory', 3, 'DAYS', 'HOURS');
+    NewRelic.recordMetric('fakeName', 'fakeCategory', 2, NewRelic.MetricUnit.SECONDS);
+    NewRelic.recordMetric('fakeName', 'fakeCategory', -1, NewRelic.MetricUnit.SECONDS, NewRelic.MetricUnit.PERCENT);
+    NewRelic.recordMetric('fakeName', 'fakeCategory', 10, null, NewRelic.MetricUnit.BYTES_PER_SECOND);
+    NewRelic.recordMetric('fakeName', 'fakeCategory', 3, NewRelic.MetricUnit.MINUTES, NewRelic.MetricUnit.SECONDS);
+    NewRelic.recordMetric('fakeName', 'fakeCategory', 3, NewRelic.MetricUnit.PERCENT, NewRelic.MetricUnit.HOURS);
+    NewRelic.recordMetric('fakeName', 'fakeCategory', 3, "DAYS", "HOURS");
     expect(MockNRM.recordMetric.mock.calls.length).toBe(0);
   });
 


### PR DESCRIPTION
- Adds configuration in the start call to allow for setting log levels. Currently the supported log levels from least verbose to most verbose are:
    - ERROR
    - WARNING
    - INFO
    - VERBOSE
    - AUDIT
- Fixes `webViewInstrumentation` configuration step to allow for web view instrumentation on iOS devices
- Updates `loggingEnabled` configuration step to include iOS now
    - Sets log level to `NRLogLevelNone` if this flag is false

