### PR TITLE
Update Android install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,15 @@ AppToken is platform-specific. You need to generate the seprate token for Androi
   ```
 
 3. Update `app/build.gradle`:
-  ```groovy
-    plugins {
-      id 'newrelic'
-    }
-  
-  ```
+```groovy
+plugins {
+  id 'newrelic'
+}  
+```
+For legacy plugin application:
+```groovy
+apply plugin: 'newrelic'
+```
 
 4. Make sure your app requests INTERNET and ACCESS_NETWORK_STATE permissions by adding these lines to your `AndroidManifest.xml`
   ```


### PR DESCRIPTION
This PR updates the readme to fix android instructions. On a react native `0.68.6` project wouldn't accept this in any part of the `app/build.gradle`:

```groovy
  plugins {
    id 'newrelic'
  }
```

I tried to find other examples of using the above  `plugins` syntax to no avail. Finally I figured out that I had to add this to the top of my `app/build.gradle` for it to compile properly: 

```groovy
apply plugin: 'newrelic'
```

For future searchability, here's the error message that is generated when trying to compile without the plugin applied:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:installDebug'.
> java.util.concurrent.ExecutionException: com.android.builder.testing.api.DeviceException: com.android.ddmlib.InstallException: EOF```