### PR TITLE
fix: remove attempt to change immutable object

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,6 @@ class NewRelic {
    * @param enabled {boolean} Boolean value for enabling analytics events.
    */
   analyticsEventEnabled(enabled) {
-    this.agentConfiguration.analyticsEventEnabled = enabled;
     this.NRMAModularAgentWrapper.execute('analyticsEventEnabled', enabled);
   }
   
@@ -191,7 +190,6 @@ class NewRelic {
    * @param enabled {boolean} Boolean value for enabling successful HTTP requests.
    */
   networkRequestEnabled(enabled) {
-    this.agentConfiguration.networkRequestEnabled = enabled;
     this.NRMAModularAgentWrapper.execute('networkRequestEnabled', enabled);
   }
 
@@ -200,7 +198,6 @@ class NewRelic {
    * @param enabled {boolean} Boolean value for enabling network request errors.
    */
   networkErrorRequestEnabled(enabled) {
-    this.agentConfiguration.networkErrorRequestEnabled = enabled;
     this.NRMAModularAgentWrapper.execute('networkErrorRequestEnabled', enabled);
   }
 
@@ -209,7 +206,6 @@ class NewRelic {
    * @param enabled {boolean} Boolean value for enabling HTTP response bodies.
    */
   httpResponseBodyCaptureEnabled(enabled) {
-    this.agentConfiguration.httpResponseBodyCaptureEnabled = enabled;
     this.NRMAModularAgentWrapper.execute('httpResponseBodyCaptureEnabled', enabled);
   }
   

--- a/ios/bridge/NRMModularAgent.m
+++ b/ios/bridge/NRMModularAgent.m
@@ -43,11 +43,11 @@ RCT_EXPORT_METHOD(startAgent:(NSString* _Nonnull)appKey agentVersion:(NSString* 
         [NewRelic disableFeatures:NRFeatureFlag_CrashReporting];
     }
     
-     if ([[agentConfig objectForKey:@"networkRequestEnabled"]boolValue] == NO){
+    if ([[agentConfig objectForKey:@"networkRequestEnabled"]boolValue] == NO){
         [NewRelic disableFeatures:NRFeatureFlag_NetworkRequestEvents];
     }
 
-     if ([[agentConfig objectForKey:@"networkErrorRequestEnabled"]boolValue] == NO){
+    if ([[agentConfig objectForKey:@"networkErrorRequestEnabled"]boolValue] == NO){
         [NewRelic disableFeatures:NRFeatureFlag_RequestErrorEvents];
     }
     


### PR DESCRIPTION
Changing agentConfiguration after agent start will result in an error where it will change the value of a frozen object.
We do not use agentConfiguration object after agent start, so no loss of data expected.