### PR TITLE
Update Licence field in package.json to match LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-native"
   ],
   "author": "New Relic",
-  "license": "New Relic",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/newrelic/newrelic-react-native-agent",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
In the `package.json`, this project had `"license": "New Relic"`, which is not a valid license type that I'm aware of. I am working on a mobile app for an enterprise client that does dependency analysis to ensure all of our dependencies are permissable for use in their organization, and the tool flagged this project due to the unrecognized license.

This PR just updates the field to be "Apache-2.0" to match the license specified in the [LICENSE](https://github.com/newrelic/newrelic-react-native-agent/blob/main/LICENSE) file.