### PR TITLE
fix:  #187

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ class NewRelic {
      */
     startAgent(appkey, customerConfiguration) {
         this.LOG.verbose = true; // todo: should let this get set by a param
-        this.config = Object.assign(this.agentConfiguration, customerConfiguration);
+        this.config = {...this.agentConfiguration, ...customerConfiguration};
         this.NRMAModularAgentWrapper.startAgent(appkey, this.agentVersion, this.getReactNativeVersion(), this.config);
         this.addNewRelicErrorHandler();
         this.addNewRelicPromiseRejectionHandler();

--- a/new-relic/__tests__/new-relic.spec.js
+++ b/new-relic/__tests__/new-relic.spec.js
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0 
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { Platform } from 'react-native';
 import NewRelic from '../../index';
 import MockNRM from '../../__mocks__/nrm-modular-agent';
-import NRMAModularAgentWrapper from '../nrma-modular-agent-wrapper';      
+import NRMAModularAgentWrapper from '../nrma-modular-agent-wrapper';
 
 let testHandler = [];
 let tracker =[];
@@ -71,23 +71,23 @@ describe('New Relic', () => {
   });
 
   it('should have correct default configuration settings', () => {
-    expect(NewRelic.agentConfiguration.analyticsEventEnabled).toBe(true);
-    expect(NewRelic.agentConfiguration.crashReportingEnabled).toBe(true);
-    expect(NewRelic.agentConfiguration.interactionTracingEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.networkRequestEnabled).toBe(true);
-    expect(NewRelic.agentConfiguration.networkErrorRequestEnabled).toBe(true);
-    expect(NewRelic.agentConfiguration.httpResponseBodyCaptureEnabled).toBe(true);
-    expect(NewRelic.agentConfiguration.loggingEnabled).toBe(true);
-    expect(NewRelic.agentConfiguration.logLevel).toBe(NewRelic.LogLevel.INFO);
-    expect(NewRelic.agentConfiguration.webViewInstrumentation).toBe(true);
-    expect(NewRelic.agentConfiguration.collectorAddress).toBe("");
-    expect(NewRelic.agentConfiguration.crashCollectorAddress).toBe("");
-    expect(NewRelic.agentConfiguration.fedRampEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.nativeCrashReportingEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.offlineStorageEnabled).toBe(true);
-    expect(NewRelic.agentConfiguration.newEventSystemEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.backgroundReportingEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.distributedTracingEnabled).toBe(true);
+    expect(NewRelic.config.analyticsEventEnabled).toBe(true);
+    expect(NewRelic.config.crashReportingEnabled).toBe(true);
+    expect(NewRelic.config.interactionTracingEnabled).toBe(false);
+    expect(NewRelic.config.networkRequestEnabled).toBe(true);
+    expect(NewRelic.config.networkErrorRequestEnabled).toBe(true);
+    expect(NewRelic.config.httpResponseBodyCaptureEnabled).toBe(true);
+    expect(NewRelic.config.loggingEnabled).toBe(true);
+    expect(NewRelic.config.logLevel).toBe(NewRelic.LogLevel.INFO);
+    expect(NewRelic.config.webViewInstrumentation).toBe(true);
+    expect(NewRelic.config.collectorAddress).toBe("");
+    expect(NewRelic.config.crashCollectorAddress).toBe("");
+    expect(NewRelic.config.fedRampEnabled).toBe(false);
+    expect(NewRelic.config.nativeCrashReportingEnabled).toBe(false);
+    expect(NewRelic.config.offlineStorageEnabled).toBe(true);
+    expect(NewRelic.config.newEventSystemEnabled).toBe(false);
+    expect(NewRelic.config.backgroundReportingEnabled).toBe(false);
+    expect(NewRelic.config.distributedTracingEnabled).toBe(true);
   });
 
   it('should change default agent configuration when configuration is passed into the start call', () => {
@@ -113,51 +113,51 @@ describe('New Relic', () => {
 
     NewRelic.startAgent("12345", customerConfiguration);
 
-    expect(NewRelic.agentConfiguration.analyticsEventEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.crashReportingEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.interactionTracingEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.networkRequestEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.networkErrorRequestEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.httpResponseBodyCaptureEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.loggingEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.logLevel).toBe("AUDIT");
-    expect(NewRelic.agentConfiguration.webViewInstrumentation).toBe(false);
-    expect(NewRelic.agentConfiguration.collectorAddress).toBe("gov-mobile-collector.newrelic.com");
-    expect(NewRelic.agentConfiguration.crashCollectorAddress).toBe("gov-mobile-crash.newrelic.com");
-    expect(NewRelic.agentConfiguration.fedRampEnabled).toBe(true);
-    expect(NewRelic.agentConfiguration.offlineStorageEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.nativeCrashReportingEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.newEventSystemEnabled).toBe(false);
-    expect(NewRelic.agentConfiguration.backgroundReportingEnabled).toBe(true);
-    expect(NewRelic.agentConfiguration.distributedTracingEnabled).toBe(false);
+    expect(NewRelic.config.analyticsEventEnabled).toBe(false);
+    expect(NewRelic.config.crashReportingEnabled).toBe(false);
+    expect(NewRelic.config.interactionTracingEnabled).toBe(false);
+    expect(NewRelic.config.networkRequestEnabled).toBe(false);
+    expect(NewRelic.config.networkErrorRequestEnabled).toBe(false);
+    expect(NewRelic.config.httpResponseBodyCaptureEnabled).toBe(false);
+    expect(NewRelic.config.loggingEnabled).toBe(false);
+    expect(NewRelic.config.logLevel).toBe("AUDIT");
+    expect(NewRelic.config.webViewInstrumentation).toBe(false);
+    expect(NewRelic.config.collectorAddress).toBe("gov-mobile-collector.newrelic.com");
+    expect(NewRelic.config.crashCollectorAddress).toBe("gov-mobile-crash.newrelic.com");
+    expect(NewRelic.config.fedRampEnabled).toBe(true);
+    expect(NewRelic.config.offlineStorageEnabled).toBe(false);
+    expect(NewRelic.config.nativeCrashReportingEnabled).toBe(false);
+    expect(NewRelic.config.newEventSystemEnabled).toBe(false);
+    expect(NewRelic.config.backgroundReportingEnabled).toBe(true);
+    expect(NewRelic.config.distributedTracingEnabled).toBe(false);
   });
 
   it('should set the analytics event flag', () => {
     NewRelic.analyticsEventEnabled(true);
     NewRelic.analyticsEventEnabled(false);
     expect(MockNRM.analyticsEventEnabled.mock.calls.length).toBe(2);
-    expect(NewRelic.agentConfiguration.analyticsEventEnabled).toBe(false);
+    expect(NewRelic.config.analyticsEventEnabled).toBe(false);
   });
 
   it('should set the network request flag', () => {
     NewRelic.networkRequestEnabled(true);
     NewRelic.networkRequestEnabled(false);
     expect(MockNRM.networkRequestEnabled.mock.calls.length).toBe(2);
-    expect(NewRelic.agentConfiguration.networkRequestEnabled).toBe(false);
+    expect(NewRelic.config.networkRequestEnabled).toBe(false);
   });
 
   it('should set the network error request flag', () => {
     NewRelic.networkErrorRequestEnabled(true);
     NewRelic.networkErrorRequestEnabled(false);
     expect(MockNRM.networkErrorRequestEnabled.mock.calls.length).toBe(2);
-    expect(NewRelic.agentConfiguration.networkErrorRequestEnabled).toBe(false);
+    expect(NewRelic.config.networkErrorRequestEnabled).toBe(false);
   });
 
   it('should set the http response body flag', () => {
     NewRelic.httpResponseBodyCaptureEnabled(true);
     NewRelic.httpResponseBodyCaptureEnabled(false);
     expect(MockNRM.httpResponseBodyCaptureEnabled.mock.calls.length).toBe(2);
-    expect(NewRelic.agentConfiguration.httpResponseBodyCaptureEnabled).toBe(false);
+    expect(NewRelic.config.httpResponseBodyCaptureEnabled).toBe(false);
   });
 
   it('should record a valid breadcrumb', () => {
@@ -256,7 +256,7 @@ describe('New Relic', () => {
 
   it('should record JS error with a given valid error', async () => {
     NewRelic.setJSAppVersion('new version 123');
-    
+
     await NewRelic.recordError(new TypeError);
     await NewRelic.recordError(new Error);
     await NewRelic.recordError(new EvalError);
@@ -269,7 +269,7 @@ describe('New Relic', () => {
 
   it('should not record JS error with a bad error', async () => {
     NewRelic.setJSAppVersion('123');
-    
+
     await NewRelic.recordError(undefined);
     await NewRelic.recordError(null);
     await NewRelic.recordError(123);
@@ -421,7 +421,7 @@ describe('New Relic', () => {
   });
 
   it('sends console.warn to record custom Events', () => {
-    // Each agent start call is 2 custom event calls (12 actual calls prior to this test) + 1 console log test = 25 
+    // Each agent start call is 2 custom event calls (12 actual calls prior to this test) + 1 console log test = 25
     NewRelic.startAgent("12345");
     console.log('hello');
     console.warn('hello');
@@ -433,9 +433,9 @@ describe('New Relic', () => {
 
     NewRelic.state.isFirstScreen = false;
     var event = {"initialProps":{"componentId":"Component4"},"rootTag":11};
-    
+
     NewRelic.componentDidAppearListener(event);
-    
+
     expect(MockNRM.recordBreadcrumb.mock.calls.length).toBe(1);
   });
 
@@ -443,9 +443,9 @@ describe('New Relic', () => {
 
     NewRelic.state.isFirstScreen = false;
     var event = {"initialProps":{"componentId":"Component4"},"rootTag":11};
-    
+
     NewRelic.componentDidAppearListener(event);
-    
+
     expect(MockNRM.recordBreadcrumb.mock.calls.length).toBe(0);
   });
 
@@ -453,9 +453,9 @@ describe('New Relic', () => {
 
     NewRelic.state.isFirstScreen = false;
     var newState = {"index": 1, "isTransitioning": false, "key": "StackRouterRoot", "routes": [{"key": "id-1660675098665-0", "routeName": "Home"}, {"key": "id-1660675098665-1", "params": [Object], "routeName": "Profile"}]};
-    
+
     NewRelic.onNavigationStateChange('',newState,'');
-    
+
     expect(MockNRM.recordBreadcrumb.mock.calls.length).toBe(1);
   });
 
@@ -463,9 +463,9 @@ describe('New Relic', () => {
 
     NewRelic.state.isFirstScreen = false;
     var newState = {"index": 1, "key": "stack-YjJKdS9Cyw2S_9eqBwGy5", "routeNames": ["Home", "HttpDemo", "ErrorDemo", "CustomDataDemo"], "routes": [{"key": "Home-04bWmlOhC_9ZpO6vsNNai", "name": "Home", "params": undefined}, {"key": "HttpDemo-zQsn6TtkDwiNm4A4OSw32", "name": "HttpDemo", "params": [Object], "path": undefined}], "stale": false, "type": "stack"};
-    
+
     NewRelic.onStateChange(newState);
-    
+
     expect(MockNRM.recordBreadcrumb.mock.calls.length).toBe(1);
   });
 


### PR DESCRIPTION
Replace the use of `Object.assign` with the spread operator in `index.js` to avoid the error with `deepFreezeAndThrowOnMutationInDev` (#187).