### PR TITLE
fix: prevent cng permission pollution

### DIFF
--- a/plugin/build/android/permissions.js
+++ b/plugin/build/android/permissions.js
@@ -14,7 +14,7 @@ const constants_1 = require("./constants");
 const withNetworkAcessPermission = config => {
     return (0, config_plugins_1.withAndroidManifest)(config, async (config) => {
         let androidManifest = config.modResults;
-        config_plugins_1.AndroidConfig.Permissions.addPermission(androidManifest, constants_1.networkAcessStatePermission);
+        config_plugins_1.AndroidConfig.Permissions.ensurePermission(androidManifest, constants_1.networkAcessStatePermission);
         return config;
     });
 };

--- a/plugin/src/android/permissions.ts
+++ b/plugin/src/android/permissions.ts
@@ -15,7 +15,7 @@ export const withNetworkAcessPermission: ConfigPlugin = config => {
     return withAndroidManifest(config, async config => {
         let androidManifest = config.modResults
 
-        AndroidConfig.Permissions.addPermission(androidManifest,networkAcessStatePermission);
+        AndroidConfig.Permissions.ensurePermission(androidManifest,networkAcessStatePermission);
     
         return config
       })


### PR DESCRIPTION
`ensurePermission` checks if another plugin adds the permission (or if the permission was added in a previous `prebuild` invocation). Prevents excess churn in `AndroidManifest.xml` when using an Expo prebuild workflow.