### PR TITLE
fix logAll attributes type

### DIFF
--- a/index.js
+++ b/index.js
@@ -512,7 +512,7 @@ class NewRelic {
      * This function is used to log all attributes.
      *
      * @param {Error} error - The error object from which the message is extracted.
-     * @param {Record<string, string | number | boolean>} attributes - A map of attributes to be logged.
+     * @param {Record<string, string | number | boolean>} attributes - The attributes to be logged.
      */
     logAll(error, attributes) {
         // Create a new Map to store all attributes

--- a/index.js
+++ b/index.js
@@ -512,7 +512,7 @@ class NewRelic {
      * This function is used to log all attributes.
      *
      * @param {Error} error - The error object from which the message is extracted.
-     * @param {Map} attributes - A map of attributes to be logged.
+     * @param {Record<string, string | number | boolean>} attributes - A map of attributes to be logged.
      */
     logAll(error, attributes) {
         // Create a new Map to store all attributes


### PR DESCRIPTION
Currently logAll attributes (second arg) is typed as Map which is incorrect and it should be Record 

```
    logAll(error: Error, attributes: Map<any, any>): void;
```

to

```
    logAll(error: Error, attributes: Record<string, string | number | boolean>): void;
```