### PR TITLE
chore: Update native agents to v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 1.6.0
+
+## Improvements
+
+- Updated the Native Android agent to version 7.6.14.
+
+
 ## 1.5.12
 
 ## Improvements

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Or, if you are using the traditional way to apply the plugin:
      }
      dependencies {
        ...
-       classpath "com.newrelic.agent.android:agent-gradle-plugin:7.6.13"
+       classpath "com.newrelic.agent.android:agent-gradle-plugin:7.6.14"
      }
    }
    ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-react-native-agent",
-  "version": "1.5.12",
+  "version": "1.6.0",
   "description": "A New Relic Mobile Agent for React Native",
   "main": "./index.js",
   "types": "./dist/index.d.ts",
@@ -94,7 +94,7 @@
       "newrelic": "~>7.6.0"
     },
     "android": {
-      "newrelic": "7.6.13",
+      "newrelic": "7.6.14",
       "ndk": "1.1.3"
     }
   }


### PR DESCRIPTION
- Updated Android agent from 7.6.13 to 7.6.14
- Bumped plugin version from 1.5.12 to 1.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)