### PR TITLE
feat: add NRBlockView component for session replay

### DIFF
--- a/android/src/main/java/com/NewRelic/NRMModularAgentPackage.java
+++ b/android/src/main/java/com/NewRelic/NRMModularAgentPackage.java
@@ -27,6 +27,6 @@ public class NRMModularAgentPackage implements ReactPackage {
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-      return Arrays.<ViewManager>asList(new SessionReplayReactNativeMaskViewManager(), new SessionReplayReactNativeUnMaskViewManager());
+      return Arrays.<ViewManager>asList(new SessionReplayReactNativeMaskViewManager(), new SessionReplayReactNativeUnMaskViewManager(), new SessionReplayReactNativeBlockViewManager());
     }
 }

--- a/android/src/main/java/com/NewRelic/SessionReplayReactNativeBlockViewManager.java
+++ b/android/src/main/java/com/NewRelic/SessionReplayReactNativeBlockViewManager.java
@@ -1,0 +1,25 @@
+package com.NewRelic;
+
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.views.view.ReactViewGroup;
+import com.facebook.react.views.view.ReactViewManager;
+
+public class SessionReplayReactNativeBlockViewManager extends ReactViewManager {
+
+    @Override
+    public String getName() {
+        return "NRBlockComponentView";
+    }
+
+    @NonNull
+    @Override
+    public ReactViewGroup createViewInstance(@NonNull ThemedReactContext context) {
+        ReactViewGroup viewGroup = super.createViewInstance(context);
+        viewGroup.setTag(com.newrelic.agent.android.R.id.newrelic_privacy,"nr-block");
+        return viewGroup;
+    }
+}

--- a/index.js
+++ b/index.js
@@ -735,4 +735,4 @@ export default newRelic;
 
 
 
-export { NewRelicMask, NewRelicUnmask } from './new-relic/replay/newrelic-mask-view';
+export { NewRelicMask, NewRelicUnmask, NewRelicBlock } from './new-relic/replay/newrelic-mask-view';

--- a/ios/bridge/RCTNRBlockViewManager.m
+++ b/ios/bridge/RCTNRBlockViewManager.m
@@ -1,0 +1,20 @@
+#import <React/RCTViewManager.h>
+#import <React/RCTView.h>
+
+@interface NRBlockComponentViewManager : RCTViewManager
+@end
+
+@implementation NRBlockComponentViewManager
+
+RCT_EXPORT_MODULE(NRBlockComponentView)
+
+- (UIView *)view
+{
+
+  UIView *view = [[RCTView alloc] init];
+  view.accessibilityIdentifier = @"nr-block";
+  return view;
+}
+
+
+@end

--- a/new-relic/replay/newrelic-mask-view.js
+++ b/new-relic/replay/newrelic-mask-view.js
@@ -2,3 +2,4 @@ import { requireNativeComponent } from 'react-native';
 
 export const NewRelicMask = requireNativeComponent('NRMaskComponentView');
 export const NewRelicUnmask = requireNativeComponent('NRUnMaskComponentView');
+export const NewRelicBlock = requireNativeComponent('NRBlockComponentView');


### PR DESCRIPTION
Add NewRelicBlock React Native component that wraps native block view functionality. Views wrapped in NewRelicBlock are completely hidden (replaced with a placeholder) in session replay recordings.