### PR TITLE
chore: release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+
+## 1.8.1
+
+## Improvements
+
+- Updated the Native iOS agent to version 7.7.1.
+- Updated the Native Android agent to version 7.7.2.
+- Added `NRBlockView` component for session replay. Views wrapped in `NRBlockView` are completely hidden (replaced with a placeholder) in session replay recordings.
+
 ## 1.8.0
 
 ## Improvements
@@ -6,7 +15,7 @@
 - Updated the Native iOS agent to version 7.7.0. 
 
 
-## 1.8.0
+## 1.7.2
 
 ## Improvements
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ In android/settings.gradle:
    plugins {
       id "com.android.application" version "7.4.2" apply false
       id "org.jetbrains.kotlin.android" version "1.7.10" apply false
-      id "com.newrelic.agent.android" version "7.6.6" apply false // <-- include this
+      id "com.newrelic.agent.android" version "7.7.2" apply false // <-- include this
    }
    ```
 
@@ -181,7 +181,7 @@ Or, if you are using the traditional way to apply the plugin:
      }
      dependencies {
        ...
-       classpath "com.newrelic.agent.android:agent-gradle-plugin:7.7.1"
+       classpath "com.newrelic.agent.android:agent-gradle-plugin:7.7.2"
      }
    }
    ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-react-native-agent",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A New Relic Mobile Agent for React Native",
   "main": "./index.js",
   "types": "./dist/index.d.ts",
@@ -91,10 +91,10 @@
   },
   "sdkVersions": {
     "ios": {
-      "newrelic": "~>7.7.0"
+      "newrelic": "~>7.7.1"
     },
     "android": {
-      "newrelic": "7.7.1",
+      "newrelic": "7.7.2",
       "ndk": "1.1.3"
     }
   }


### PR DESCRIPTION
## What & Why

Release 1.8.1 of the New Relic React Native agent.

## Changes

- Bumped package version to 1.8.1
- Updated Native iOS agent to 7.7.1
- Updated Native Android agent to 7.7.2
- Updated Android Gradle plugin version references in README to 7.7.2
- Added `NRBlockView` component for session replay — views wrapped in `NRBlockView` are completely hidden (replaced with a placeholder) in session replay recordings

## Test plan

- All unit tests pass (`npm test`)
- Verify changelog and version bump are correct