### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,7 @@
 name: Run codecov and upload coverage
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-react-native-agent/security/code-scanning/1](https://github.com/newrelic/newrelic-react-native-agent/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/codecov.yml` so the workflow does not inherit potentially over-privileged defaults.  
Best fix without changing behavior: define minimal read access at the workflow root so all jobs inherit it unless overridden.

For this specific file, insert:

```yml
permissions:
  contents: read
```

right after the `on:` declaration (before `jobs:`). This satisfies CodeQL’s requirement and documents least privilege while preserving current workflow functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
