### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/example-manual.yml
+++ b/.github/workflows/example-manual.yml
@@ -1,6 +1,7 @@
 # This is a basic workflow that is manually triggered
 
 name: Manual workflow
+permissions: {}
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-react-native-agent/security/code-scanning/3](https://github.com/newrelic/newrelic-react-native-agent/security/code-scanning/3)

To fix this, add an explicit `permissions` block in `.github/workflows/example-manual.yml` at the workflow root (right after `name` is a good location). Since this workflow only runs `echo`, it does not need write permissions. The safest least-privilege option is an empty map `permissions: {}`, which disables all `GITHUB_TOKEN` scopes for all jobs unless explicitly overridden. This directly resolves the CodeQL finding without changing functionality.

Concretely:
- File: `.github/workflows/example-manual.yml`
- Region: near the top-level keys, after `name: Manual workflow` and before `on:`
- Change: insert
  ```yml
  permissions: {}
  ```

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
