### PR TITLE
fix: [NR-536393] align logLevel handling across JS, iOS, and Android bridges

### DIFF
--- a/android/src/main/java/com/NewRelic/NRMModularAgentModuleImpl.java
+++ b/android/src/main/java/com/NewRelic/NRMModularAgentModuleImpl.java
@@ -126,13 +126,14 @@ public class NRMModularAgentModuleImpl {
 
             Map<String, Integer> strToLogLevel = new HashMap<>();
             strToLogLevel.put("ERROR", AgentLog.ERROR);
-            strToLogLevel.put("WARNING", AgentLog.WARN);
+            strToLogLevel.put("WARN", AgentLog.WARN);
             strToLogLevel.put("INFO", AgentLog.INFO);
             strToLogLevel.put("VERBOSE", AgentLog.VERBOSE);
             strToLogLevel.put("AUDIT", AgentLog.AUDIT);
+            strToLogLevel.put("DEBUG", AgentLog.DEBUG);
 
-            // INFO is default log level
-            int logLevel = AgentLog.INFO;
+            // WARN is default log level
+            int logLevel = AgentLog.WARN;
             if (agentConfig.get("logLevel") != null) {
                 String configLogLevel = (String) agentConfig.get("logLevel");
                 if(configLogLevel != null) {

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ class NewRelic {
         networkErrorRequestEnabled: true,
         httpResponseBodyCaptureEnabled: true,
         loggingEnabled: true,
-        logLevel: this.LogLevel.INFO,
+        logLevel: this.LogLevel.WARN,
         webViewInstrumentation: true,
         collectorAddress: "",
         crashCollectorAddress: "",
@@ -462,7 +462,7 @@ class NewRelic {
     /**
      * This function is used to log a message with a specific log level.
      *
-     * @param {string} logLevel - The level of the log (e.g., ERROR, WARNING, INFO, VERBOSE, AUDIT).
+     * @param {string} logLevel - The level of the log (e.g., ERROR, WARN, INFO, VERBOSE, AUDIT, DEBUG).
      * @param {string} message - The message to be logged.
      */
     log(logLevel, message) {

--- a/ios/bridge/NRMModularAgent.mm
+++ b/ios/bridge/NRMModularAgent.mm
@@ -388,10 +388,11 @@ RCT_EXPORT_METHOD(startAgent:(NSString *)appkey agentVersion:(NSString *)agentVe
     NRLogLevels logLevel = NRLogLevelWarning;
     NSDictionary *logDict = @{
         @"ERROR": [NSNumber numberWithInt:NRLogLevelError],
-        @"WARNING": [NSNumber numberWithInt:NRLogLevelWarning],
+        @"WARN": [NSNumber numberWithInt:NRLogLevelWarning],
         @"INFO": [NSNumber numberWithInt:NRLogLevelInfo],
         @"VERBOSE": [NSNumber numberWithInt:NRLogLevelVerbose],
         @"AUDIT": [NSNumber numberWithInt:NRLogLevelAudit],
+        @"DEBUG": [NSNumber numberWithInt:NRLogLevelDebug],
     };
 
     
@@ -401,7 +402,7 @@ RCT_EXPORT_METHOD(startAgent:(NSString *)appkey agentVersion:(NSString *)agentVe
             configLogLevel = [configLogLevel uppercaseString];
             NSNumber* newLogLevel = [logDict valueForKey:configLogLevel];
             if(newLogLevel != nil) {
-                logLevel = NRLogLevelALL;
+                logLevel = (NRLogLevels)[newLogLevel intValue];
             }
         }
     }

--- a/jestSetup.js
+++ b/jestSetup.js
@@ -9,11 +9,12 @@ jest.mock('./index.js', () => ({
   incrementAttribute: jest.fn(),
   isAgentStarted: jest.fn(),
   LogLevel: {
-    AUDIT: 'AUDIT',
     ERROR: 'ERROR',
+    WARN: 'WARN',
     INFO: 'INFO',
     VERBOSE: 'VERBOSE',
-    WARNING: 'WARNING'
+    AUDIT: 'AUDIT',
+    DEBUG: 'DEBUG'
   },
   networkErrorRequestEnabled: jest.fn(),
   networkRequestEnabled: jest.fn(),

--- a/new-relic/__tests__/new-relic.spec.js
+++ b/new-relic/__tests__/new-relic.spec.js
@@ -78,7 +78,7 @@ describe('New Relic', () => {
     expect(NewRelic.config.networkErrorRequestEnabled).toBe(true);
     expect(NewRelic.config.httpResponseBodyCaptureEnabled).toBe(true);
     expect(NewRelic.config.loggingEnabled).toBe(true);
-    expect(NewRelic.config.logLevel).toBe(NewRelic.LogLevel.INFO);
+    expect(NewRelic.config.logLevel).toBe(NewRelic.LogLevel.WARN);
     expect(NewRelic.config.webViewInstrumentation).toBe(true);
     expect(NewRelic.config.collectorAddress).toBe("");
     expect(NewRelic.config.crashCollectorAddress).toBe("");


### PR DESCRIPTION
- iOS: stop discarding the resolved level and clobbering it to NRLogLevelALL; now applies the value looked up from the level dictionary
- iOS/Android: accept WARN (matching the JS LogLevel enum and SDK conventions) instead of WARNING, and add DEBUG
- Default log level is now WARN on both platforms (was INFO on Android and effectively ALL on iOS due to the bug above)
- jestSetup mock LogLevel updated to match the real enum