### PR TITLE
fix: rename JSError feature flag to MobileError and recordJavascriptError to recordError

### DIFF
--- a/__mocks__/nrm-modular-agent.js
+++ b/__mocks__/nrm-modular-agent.js
@@ -36,7 +36,7 @@ export default  {
   componentDidAppearListener:jest.fn(),
   onStateChange:jest.fn(),
   recordHandledException:jest.fn(),
-  recordJavascriptError:jest.fn(),
+  recordError:jest.fn(),
   shutdown:jest.fn(),
   recordReplay:jest.fn(),
   pauseReplay:jest.fn(),

--- a/android/src/main/java/com/NewRelic/NRMModularAgentModuleImpl.java
+++ b/android/src/main/java/com/NewRelic/NRMModularAgentModuleImpl.java
@@ -126,9 +126,9 @@ public class NRMModularAgentModuleImpl {
 
             Object jsErrorReportingEnabled = agentConfig.get("jsErrorReportingEnabled");
             if (jsErrorReportingEnabled == null || (Boolean) jsErrorReportingEnabled) {
-                NewRelic.enableFeature(FeatureFlag.JSError);
+                NewRelic.enableFeature(FeatureFlag.MobileError);
             } else {
-                NewRelic.disableFeature(FeatureFlag.JSError);
+                NewRelic.disableFeature(FeatureFlag.MobileError);
             }
 
             Map<String, Integer> strToLogLevel = new HashMap<>();
@@ -511,7 +511,7 @@ public class NRMModularAgentModuleImpl {
         NewRelic.recordHandledException(exception, exceptionMap);
     }
 
-    public void recordJavaScriptError(String errorName, String errorMessage,
+    public void recordError(String errorName, String errorMessage,
                                       String stackString, boolean isFatal,
                                       ReadableMap attributes) {
         if (errorName == null || errorMessage == null) {
@@ -524,7 +524,7 @@ public class NRMModularAgentModuleImpl {
             attributeMap = attributes.toHashMap();
         }
 
-        NewRelic.recordJavaScriptError(
+        NewRelic.recordError(
             errorName,
             errorMessage,
             stackString != null ? stackString : "",

--- a/android/src/newarch/java/com/NewRelic/NRMModularAgentModule.java
+++ b/android/src/newarch/java/com/NewRelic/NRMModularAgentModule.java
@@ -205,10 +205,10 @@ public class NRMModularAgentModule extends NativeNewRelicModuleSpec {
     }
 
     @Override
-    public void recordJavascriptError(String errorName, String errorMessage,
+    public void recordError(String errorName, String errorMessage,
                                       String stackString, boolean isFatal,
                                       ReadableMap attributes) {
-        impl.recordJavaScriptError(errorName, errorMessage, stackString, isFatal,
+        impl.recordError(errorName, errorMessage, stackString, isFatal,
                                    attributes);
     }
 }

--- a/android/src/oldarch/java/com/NewRelic/NRMModularAgentModule.java
+++ b/android/src/oldarch/java/com/NewRelic/NRMModularAgentModule.java
@@ -214,10 +214,10 @@ public class NRMModularAgentModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void recordJavascriptError(String errorName, String errorMessage,
+    public void recordError(String errorName, String errorMessage,
                                       String stackString, boolean isFatal,
                                       ReadableMap attributes) {
-        impl.recordJavaScriptError(errorName, errorMessage, stackString, isFatal,
+        impl.recordError(errorName, errorMessage, stackString, isFatal,
                                    attributes);
     }
 }

--- a/index.js
+++ b/index.js
@@ -353,7 +353,7 @@ class NewRelic {
 
         if (error !== undefined) {
             this.NRMAModularAgentWrapper.execute(
-                "recordJavascriptError",
+                "recordError",
                 error.name || 'Error',
                 error.message || '',
                 error.stack || '',

--- a/ios/bridge/NRMModularAgent.mm
+++ b/ios/bridge/NRMModularAgent.mm
@@ -270,7 +270,7 @@ RCT_EXPORT_METHOD(recordHandledException:(NSDictionary* _Nonnull)exceptionDictio
 
 }
 
-RCT_EXPORT_METHOD(recordJavascriptError:(NSString* _Nonnull)errorName
+RCT_EXPORT_METHOD(recordError:(NSString* _Nonnull)errorName
                   errorMessage:(NSString* _Nonnull)errorMessage
                   stackString:(NSString* _Nonnull)stackString
                   isFatal:(BOOL)isFatal
@@ -284,7 +284,7 @@ RCT_EXPORT_METHOD(recordJavascriptError:(NSString* _Nonnull)errorName
         [mergedAttributes addEntriesFromDictionary:attributes];
     }
 
-    [NewRelic recordJavascriptError:errorName
+    [NewRelic recordError:errorName
                             message:errorMessage
                          stackTrace:(stackString ?: @"")
                                     isFatal:isFatal
@@ -407,7 +407,7 @@ RCT_EXPORT_METHOD(startAgent:(NSString *)appkey agentVersion:(NSString *)agentVe
 
     if ([customerConfiguration objectForKey:@"jsErrorReportingEnabled"] != nil &&
         [[customerConfiguration objectForKey:@"jsErrorReportingEnabled"] boolValue] == NO) {
-        [NewRelic disableFeatures:NRFeatureFlag_JSErrorEvents];
+        [NewRelic disableFeatures:NRFeatureFlag_MobileErrorEvents];
     }
     
     //Default is NRLogLevelWarning

--- a/new-relic/__tests__/new-relic.spec.js
+++ b/new-relic/__tests__/new-relic.spec.js
@@ -267,7 +267,7 @@ describe('New Relic', () => {
     await NewRelic.recordError(new ReferenceError);
     await NewRelic.recordError('fakeErrorName');
 
-    expect(MockNRM.recordJavascriptError.mock.calls.length).toBe(6);
+    expect(MockNRM.recordError.mock.calls.length).toBe(6);
   });
 
   it('should not record JS error with a bad error', async () => {
@@ -279,7 +279,7 @@ describe('New Relic', () => {
     await NewRelic.recordError(true);
     await NewRelic.recordError('');
 
-    expect(MockNRM.recordJavascriptError.mock.calls.length).toBe(0);
+    expect(MockNRM.recordError.mock.calls.length).toBe(0);
   });
 
   it('should set max event buffer time', () => {

--- a/new-relic/__tests__/nrma-modular-agent-wrapper.spec.js
+++ b/new-relic/__tests__/nrma-modular-agent-wrapper.spec.js
@@ -69,37 +69,37 @@ describe('nrmaModularAgentWrapper', () => {
     expect(test.hasMethod('setJSAppVersion')).toBe(true);
   });
 
-  it('should execute recordJavascriptError when agent is started', () => {
+  it('should execute recordError when agent is started', () => {
     NRMAModularAgentWrapper.isAgentStarted = true;
-    test.execute('recordJavascriptError', 'TestError', 'Test message', 'stack trace', false, {});
-    expect(MockNRM.recordJavascriptError.mock.calls.length).toBe(1);
-    expect(MockNRM.recordJavascriptError.mock.calls[0][0]).toBe('TestError');
-    expect(MockNRM.recordJavascriptError.mock.calls[0][1]).toBe('Test message');
-    expect(MockNRM.recordJavascriptError.mock.calls[0][2]).toBe('stack trace');
-    expect(MockNRM.recordJavascriptError.mock.calls[0][3]).toBe(false);
+    test.execute('recordError', 'TestError', 'Test message', 'stack trace', false, {});
+    expect(MockNRM.recordError.mock.calls.length).toBe(1);
+    expect(MockNRM.recordError.mock.calls[0][0]).toBe('TestError');
+    expect(MockNRM.recordError.mock.calls[0][1]).toBe('Test message');
+    expect(MockNRM.recordError.mock.calls[0][2]).toBe('stack trace');
+    expect(MockNRM.recordError.mock.calls[0][3]).toBe(false);
   });
 
-  it('should not execute recordJavascriptError when agent is not started', () => {
+  it('should not execute recordError when agent is not started', () => {
     NRMAModularAgentWrapper.isAgentStarted = false;
-    test.execute('recordJavascriptError', 'TestError', 'Test message', 'stack trace', false, {});
-    expect(MockNRM.recordJavascriptError.mock.calls.length).toBe(0);
+    test.execute('recordError', 'TestError', 'Test message', 'stack trace', false, {});
+    expect(MockNRM.recordError.mock.calls.length).toBe(0);
   });
 
-  it('should handle null values in recordJavascriptError with defaults', () => {
+  it('should handle null values in recordError with defaults', () => {
     NRMAModularAgentWrapper.isAgentStarted = true;
-    test.execute('recordJavascriptError', null, null, null, true, {});
-    expect(MockNRM.recordJavascriptError.mock.calls.length).toBe(1);
-    expect(MockNRM.recordJavascriptError.mock.calls[0][0]).toBe('Error');
-    expect(MockNRM.recordJavascriptError.mock.calls[0][1]).toBe('');
-    expect(MockNRM.recordJavascriptError.mock.calls[0][2]).toBe('');
-    expect(MockNRM.recordJavascriptError.mock.calls[0][3]).toBe(true);
+    test.execute('recordError', null, null, null, true, {});
+    expect(MockNRM.recordError.mock.calls.length).toBe(1);
+    expect(MockNRM.recordError.mock.calls[0][0]).toBe('Error');
+    expect(MockNRM.recordError.mock.calls[0][1]).toBe('');
+    expect(MockNRM.recordError.mock.calls[0][2]).toBe('');
+    expect(MockNRM.recordError.mock.calls[0][3]).toBe(true);
   });
 
-  it('should pass attributes to recordJavascriptError', () => {
+  it('should pass attributes to recordError', () => {
     NRMAModularAgentWrapper.isAgentStarted = true;
     const attributes = { customKey: 'customValue' };
-    test.execute('recordJavascriptError', 'Error', 'message', 'stack', false, attributes);
-    expect(MockNRM.recordJavascriptError.mock.calls.length).toBe(1);
-    expect(MockNRM.recordJavascriptError.mock.calls[0][4]).toEqual(attributes);
+    test.execute('recordError', 'Error', 'message', 'stack', false, attributes);
+    expect(MockNRM.recordError.mock.calls.length).toBe(1);
+    expect(MockNRM.recordError.mock.calls[0][4]).toEqual(attributes);
   });
 });

--- a/new-relic/nrma-modular-agent-wrapper.js
+++ b/new-relic/nrma-modular-agent-wrapper.js
@@ -211,9 +211,9 @@ class NRMAModularAgentWrapper {
     NRMModularAgent.recordStack(name, message, stack, isFatal, JSAppVersion);
   };
 
-  recordJavascriptError = (errorName, errorMessage, stackString, isFatal, attributes = {}) => {
+  recordError = (errorName, errorMessage, stackString, isFatal, attributes = {}) => {
     if (NRMAModularAgentWrapper.isAgentStarted) {
-      NRMModularAgent.recordJavascriptError(
+      NRMModularAgent.recordError(
         errorName || 'Error',
         errorMessage || '',
         stackString || '',

--- a/new-relic/spec/NativeNewRelicModule.ts
+++ b/new-relic/spec/NativeNewRelicModule.ts
@@ -32,7 +32,7 @@ export interface Spec extends TurboModule {
   recordReplay(): void;
   pauseReplay(): void;
   recordHandledException(exceptionDictionary:Object): void;
-  recordJavascriptError(
+  recordError(
     errorName: string,
     errorMessage: string,
     stackString: string,


### PR DESCRIPTION
## What & Why

The native Android and iOS New Relic agents renamed their JS-error API surface:
- `FeatureFlag.JSError` (Android) / `NRFeatureFlag_JSErrorEvents` (iOS) → `MobileError`-named flags
- Native SDK method `recordJavaScriptError`/`recordJavascriptError` → `recordError`

This updates the React Native bridge to match, renaming the whole chain from the TurboModule codegen spec down through the native SDK call on both platforms, so the wrapper keeps compiling against the updated native SDKs and stays consistent with the already-landed `MobileError` docs/event-type rename.

## Callouts

- The public developer-facing `NewRelic.recordError(e, isFatal, attributes)` API in `index.js` is unchanged — only the internal bridge method name changed.
- Pure rename, no signature change: `recordError` takes the same params as the old `recordJavascriptError`/`recordJavaScriptError` (errorName, errorMessage, stackString, isFatal, attributes).
- **Risk:** the pinned native SDK versions (`android/build.gradle` → `7.7.8-SNAPSHOT`, iOS podspec → `~>7.7.2`) may need bumping to a version that actually ships `FeatureFlag.MobileError` / `NRFeatureFlag_MobileErrorEvents` / `recordError`, or this won't compile. Locally vendored iOS Pods headers were stale and couldn't confirm the exact new symbol names against a real SDK build.

## Test plan

- [x] `new-relic/spec/NativeNewRelicModule.ts`, `new-relic/nrma-modular-agent-wrapper.js`, `index.js`, `__mocks__/nrm-modular-agent.js`, and both `__tests__` files updated for the rename
- [x] Full jest suite passes (95 tests)
- [ ] Android build/unit tests once the native SDK version pin is confirmed to expose `FeatureFlag.MobileError` / `NewRelic.recordError(...)`
- [ ] iOS build once the native SDK version pin is confirmed to expose `NRFeatureFlag_MobileErrorEvents` / `[NewRelic recordError:...]`