### PR TITLE
feat: automate New Relic map/dSYM/source-map upload for Expo apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ If only one of the two variables is set, the plugin still writes that single pro
 the Gradle task then logs which one is missing rather than failing the build. Set the
 variables for your build:
 
-* **EAS Build**: store both as [EAS environment variables](https://docs.expo.dev/eas/environment-variables/) (e.g. `eas env:create --name NEWRELIC_USER_API_KEY --visibility secret` and `eas env:create --name NEWRELIC_ANDROID_APP_TOKEN --visibility secret`) scoped to the environments you build with. EAS Build resolves them before running `prebuild`, whether the build runs on EAS's servers or locally with `eas build --local`.
+* **EAS Build**: store both as [EAS environment variables](https://docs.expo.dev/eas/environment-variables/) with `--visibility plaintext` or `--visibility sensitive` (e.g. `eas env:set --environment production --name NEWRELIC_USER_API_KEY --value <value> --visibility sensitive` and the equivalent for `NEWRELIC_ANDROID_APP_TOKEN`), scoped to the environments you build with. **Do not use `--visibility secret`** — secret-visibility variables are reserved for EAS's own credential system and are never exposed as `process.env` to build scripts, so the plugin won't see them and will silently skip writing `newrelic.properties`. EAS Build resolves plaintext/sensitive variables before running `prebuild`, whether the build runs on EAS's servers or locally with `eas build --local`.
 * **Bare `expo prebuild` / `expo run:android`**: export both variables in your shell, or add them to a `.env` file loaded by your tooling, before running the build.
 
 If neither environment variable is set, the plugin leaves `newrelic.properties` untouched and the two Gradle tasks skip the upload with a log message rather than failing the build.

--- a/README.md
+++ b/README.md
@@ -422,6 +422,61 @@ variables for your build:
 
 If neither environment variable is set, the plugin leaves `newrelic.properties` untouched and the two Gradle tasks skip the upload with a log message rather than failing the build.
 
+#### Automatic iOS dSYM / source map upload (Expo)
+
+Unlike Android, the dSYM and React Native source map upload scripts
+(`run-symbol-tool` and `upload-react-native-sourcemap`, from the
+[`dsym-upload-tools`](https://github.com/newrelic/newrelic-ios-agent-spm/tree/main/dsym-upload-tools)
+folder) don't ship inside the `NewRelicAgent` CocoaPod, and the Run Script build phase
+that invokes them normally has to be added by hand in Xcode — which doesn't survive
+`expo prebuild` regenerating `ios/` from scratch. The plugin vendors both scripts and,
+on every prebuild:
+
+* Copies them into `ios/dsym-upload-tools`.
+* Adds a Run Script build phase (after "Bundle React Native code and images") that runs
+  both scripts, reading credentials from environment variables — never written to any
+  generated file, only referenced by name in the build phase's shell script.
+* Ensures the "Bundle React Native code and images" phase exports `SOURCEMAP_FILE`, since
+  Expo's default template doesn't set it and the source map won't be generated otherwise.
+
+By default the build phase reads the iOS application token from `NEWRELIC_IOS_APP_TOKEN`
+and the User/Ingest API key from `NEWRELIC_USER_API_KEY` (shared with the Android
+default — same key type, [get one here](https://one.newrelic.com/api-keys)):
+
+```js
+{
+  "name": "my app",
+  "plugins": ["newrelic-react-native-agent"]
+}
+```
+
+To use different environment variable names, pass them explicitly:
+
+```js
+{
+  "name": "my app",
+  "plugins": [
+    [
+      "newrelic-react-native-agent",
+      {
+        "ios": {
+          "appTokenEnvName": "MY_NR_IOS_APP_TOKEN",
+          "apiKeyEnvName": "MY_NR_USER_API_KEY"
+        }
+      }
+    ]
+  ]
+}
+```
+
+Set the variables for your build the same way as the Android ones above (EAS environment
+variables with `plaintext`/`sensitive` visibility, or exported in your shell for bare
+`expo prebuild` / `expo run:ios`). If a variable is missing at build time, the phase logs
+which one and skips that upload rather than failing the build. Both underlying scripts
+also skip automatically for non-Release configurations and for simulator builds (the
+source map script has a `NEWRELIC_SOURCEMAP_ALLOW_SIMULATOR=true` escape hatch for
+testing the upload path on a simulator).
+
 ## Routing Instrumentation
 
 We currently provide two routing instrumentations out of the box to instrument route changes for and route changes record as Breadcrumb.
@@ -867,6 +922,9 @@ Deployment Postprocessing: Yes
 Strip Linked Product: Yes
 Strip Debug Symbols During Copy : Yes
 ```
+
+If you're using Expo, the config plugin can vendor these scripts and add the Run Script
+build phase for you automatically on every prebuild — see [Automatic iOS dSYM / source map upload (Expo)](#automatic-ios-dsym--source-map-upload-expo).
 ### Configure app launch times
 
 To measure app launch time, you can refer to the following documentation for both [Android](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-app-launch-time-android-apps/) and [iOS](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-ios/configuration/app-launch-times-ios-apps/) platforms.

--- a/README.md
+++ b/README.md
@@ -371,6 +371,57 @@ Integration with Expo is possible in both bare workflow and [custom managed work
   * After this, you need to use the `expo prebuild --clean` command as described in the  ["Adding custom native code"](https://docs.expo.dev/workflow/customizing/) guide to rebuild your app with the plugin changes. If this command is not running, you'll get errors when starting the New Relic agent.
   * For Expo Go users, the agent will require using native code. Since Expo Go does not suport sending custom native code over-the-air, you can follow Expo's documentation on how to use ["Custom native code in Expo Go"](https://docs.expo.dev/bare/using-expo-client/).
 
+#### Automatic Android source map / mapping file upload (Expo)
+
+Since `android/` is regenerated on every `expo prebuild` (locally and on EAS Build), the
+plugin can write `android/app/newrelic.properties` for you on each prebuild, sourcing
+your [New Relic User API key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#user-key)
+and your Android [application token](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile/maintenance/viewing-your-application-token)
+(the same one passed to `NewRelic.startAgent()`) from environment variables instead of
+committing them to the repo. Both values are required — the agent's
+`newrelicReactNativeSourceMapUploadRelease` and `newrelicMapUploadRelease` Gradle tasks
+read `com.newrelic.api_key` and `com.newrelic.application_token` from this file to
+authenticate the upload of the React Native source map and ProGuard/R8 mapping file
+after release builds — see [React Native JavaScript error reporting](guides/react-native-javascript-error-reporting.md).
+
+By default the plugin reads the User API key from `NEWRELIC_USER_API_KEY` and the
+application token from `NEWRELIC_ANDROID_APP_TOKEN`:
+
+```js
+{
+  "name": "my app",
+  "plugins": ["newrelic-react-native-agent"]
+}
+```
+
+To use different environment variable names, pass them explicitly:
+
+```js
+{
+  "name": "my app",
+  "plugins": [
+    [
+      "newrelic-react-native-agent",
+      {
+        "android": {
+          "apiKeyEnvName": "MY_NR_USER_API_KEY",
+          "appTokenEnvName": "MY_NR_ANDROID_APP_TOKEN"
+        }
+      }
+    ]
+  ]
+}
+```
+
+If only one of the two variables is set, the plugin still writes that single property;
+the Gradle task then logs which one is missing rather than failing the build. Set the
+variables for your build:
+
+* **EAS Build**: store both as [EAS environment variables](https://docs.expo.dev/eas/environment-variables/) (e.g. `eas env:create --name NEWRELIC_USER_API_KEY --visibility secret` and `eas env:create --name NEWRELIC_ANDROID_APP_TOKEN --visibility secret`) scoped to the environments you build with. EAS Build resolves them before running `prebuild`, whether the build runs on EAS's servers or locally with `eas build --local`.
+* **Bare `expo prebuild` / `expo run:android`**: export both variables in your shell, or add them to a `.env` file loaded by your tooling, before running the build.
+
+If neither environment variable is set, the plugin leaves `newrelic.properties` untouched and the two Gradle tasks skip the upload with a log message rather than failing the build.
+
 ## Routing Instrumentation
 
 We currently provide two routing instrumentations out of the box to instrument route changes for and route changes record as Breadcrumb.

--- a/guides/react-native-javascript-error-reporting.md
+++ b/guides/react-native-javascript-error-reporting.md
@@ -21,13 +21,23 @@ Before you begin, get the following from the same New Relic account:
 
 ### Android
 
-Add your User API key to the `newrelic.properties` file in your project:
+Add your User API key and application token to the `newrelic.properties` file in your
+project (in the app module directory, alongside `build.gradle`):
 
 ```properties
-apiKey=<YOUR_USER_API_KEY>
+com.newrelic.api_key=<YOUR_USER_API_KEY>
+com.newrelic.application_token=<YOUR_APPLICATION_TOKEN>
 ```
 
-Replace `<YOUR_USER_API_KEY>` with your User API key. The agent already knows the application token from `NewRelic.startAgent()`. When both values are valid, the agent generates and uploads the Android source map to New Relic automatically after each release build.
+Replace `<YOUR_USER_API_KEY>` with your User API key and `<YOUR_APPLICATION_TOKEN>` with
+your Android application token. The build-time Gradle task cannot see the token passed
+to `NewRelic.startAgent()` in JavaScript — that call only configures the agent at
+runtime — so `com.newrelic.application_token` must also be set in this file. When both
+values are valid, the agent generates and uploads the Android source map to New Relic
+automatically after each release build.
+
+If you're using Expo, the `newrelic-react-native-agent` config plugin can generate this
+file for you automatically on every prebuild — see the [Expo section](../README.md#automatic-android-source-map--mapping-file-upload-expo) of the main README.
 
 ### iOS
 

--- a/plugin/build/android/index.d.ts
+++ b/plugin/build/android/index.d.ts
@@ -1,9 +1,9 @@
 /**
  * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0 
+ * SPDX-License-Identifier: Apache-2.0
  */
-
 import { withApplyNewRelicPlugin } from './applyPlugin';
 import { withBuildscriptDependency } from './buildscriptDependency';
 import { withNetworkAcessPermission } from './permissions';
-export { withBuildscriptDependency, withApplyNewRelicPlugin, withNetworkAcessPermission };
+import { withNewRelicMapUploadProperties, NewRelicPluginProps, defaultApiKeyEnvName, defaultAppTokenEnvName } from './mapUploadProperties';
+export { withBuildscriptDependency, withApplyNewRelicPlugin, withNetworkAcessPermission, withNewRelicMapUploadProperties, NewRelicPluginProps, defaultApiKeyEnvName, defaultAppTokenEnvName };

--- a/plugin/build/android/index.js
+++ b/plugin/build/android/index.js
@@ -1,14 +1,17 @@
+"use strict";
 /**
  * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0 
+ * SPDX-License-Identifier: Apache-2.0
  */
-
-"use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withNetworkAcessPermission = exports.withApplyNewRelicPlugin = exports.withBuildscriptDependency = void 0;
+exports.defaultAppTokenEnvName = exports.defaultApiKeyEnvName = exports.withNewRelicMapUploadProperties = exports.withNetworkAcessPermission = exports.withApplyNewRelicPlugin = exports.withBuildscriptDependency = void 0;
 const applyPlugin_1 = require("./applyPlugin");
 Object.defineProperty(exports, "withApplyNewRelicPlugin", { enumerable: true, get: function () { return applyPlugin_1.withApplyNewRelicPlugin; } });
 const buildscriptDependency_1 = require("./buildscriptDependency");
 Object.defineProperty(exports, "withBuildscriptDependency", { enumerable: true, get: function () { return buildscriptDependency_1.withBuildscriptDependency; } });
 const permissions_1 = require("./permissions");
 Object.defineProperty(exports, "withNetworkAcessPermission", { enumerable: true, get: function () { return permissions_1.withNetworkAcessPermission; } });
+const mapUploadProperties_1 = require("./mapUploadProperties");
+Object.defineProperty(exports, "withNewRelicMapUploadProperties", { enumerable: true, get: function () { return mapUploadProperties_1.withNewRelicMapUploadProperties; } });
+Object.defineProperty(exports, "defaultApiKeyEnvName", { enumerable: true, get: function () { return mapUploadProperties_1.defaultApiKeyEnvName; } });
+Object.defineProperty(exports, "defaultAppTokenEnvName", { enumerable: true, get: function () { return mapUploadProperties_1.defaultAppTokenEnvName; } });

--- a/plugin/build/android/mapUploadProperties.d.ts
+++ b/plugin/build/android/mapUploadProperties.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ConfigPlugin } from '@expo/config-plugins';
+export declare const defaultApiKeyEnvName = "NEWRELIC_USER_API_KEY";
+export declare const defaultAppTokenEnvName = "NEWRELIC_ANDROID_APP_TOKEN";
+export type NewRelicPluginProps = {
+    android?: {
+        /**
+         * Name of the environment variable containing the New Relic User API key.
+         * Written to `newrelic.properties` as `com.newrelic.api_key`.
+         * Defaults to `NEWRELIC_USER_API_KEY`.
+         */
+        apiKeyEnvName?: string;
+        /**
+         * Name of the environment variable containing the Android application token
+         * (the same token passed to `NewRelic.startAgent()`). Written to
+         * `newrelic.properties` as `com.newrelic.application_token`.
+         * Defaults to `NEWRELIC_ANDROID_APP_TOKEN`.
+         */
+        appTokenEnvName?: string;
+    };
+};
+/**
+ * Write `android/app/newrelic.properties` with the New Relic User API key and Android
+ * application token sourced from environment variables, so the agent's
+ * `newrelicMapUploadRelease` and `newrelicReactNativeSourceMapUploadRelease` Gradle
+ * tasks can automatically upload the ProGuard/R8 mapping file and React Native source
+ * map after release builds, without committing credentials to the repo.
+ *
+ * Property names (`com.newrelic.api_key` / `com.newrelic.application_token`) match what
+ * the native `agent-gradle-plugin` reads from this file.
+ */
+export declare const withNewRelicMapUploadProperties: ConfigPlugin<NewRelicPluginProps>;

--- a/plugin/build/android/mapUploadProperties.js
+++ b/plugin/build/android/mapUploadProperties.js
@@ -1,0 +1,71 @@
+"use strict";
+/**
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withNewRelicMapUploadProperties = exports.defaultAppTokenEnvName = exports.defaultApiKeyEnvName = void 0;
+const fs = __importStar(require("fs"));
+const path = __importStar(require("path"));
+const config_plugins_1 = require("@expo/config-plugins");
+exports.defaultApiKeyEnvName = 'NEWRELIC_USER_API_KEY';
+exports.defaultAppTokenEnvName = 'NEWRELIC_ANDROID_APP_TOKEN';
+/**
+ * Write `android/app/newrelic.properties` with the New Relic User API key and Android
+ * application token sourced from environment variables, so the agent's
+ * `newrelicMapUploadRelease` and `newrelicReactNativeSourceMapUploadRelease` Gradle
+ * tasks can automatically upload the ProGuard/R8 mapping file and React Native source
+ * map after release builds, without committing credentials to the repo.
+ *
+ * Property names (`com.newrelic.api_key` / `com.newrelic.application_token`) match what
+ * the native `agent-gradle-plugin` reads from this file.
+ */
+const withNewRelicMapUploadProperties = (config, props = {}) => {
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        'android',
+        config => {
+            var _a, _b, _c, _d;
+            const apiKeyEnvName = (_b = (_a = props.android) === null || _a === void 0 ? void 0 : _a.apiKeyEnvName) !== null && _b !== void 0 ? _b : exports.defaultApiKeyEnvName;
+            const appTokenEnvName = (_d = (_c = props.android) === null || _c === void 0 ? void 0 : _c.appTokenEnvName) !== null && _d !== void 0 ? _d : exports.defaultAppTokenEnvName;
+            const apiKey = process.env[apiKeyEnvName];
+            const appToken = process.env[appTokenEnvName];
+            const lines = [];
+            if (apiKey) {
+                lines.push(`com.newrelic.api_key=${apiKey}`);
+            }
+            if (appToken) {
+                lines.push(`com.newrelic.application_token=${appToken}`);
+            }
+            if (lines.length === 0) {
+                return config;
+            }
+            const propertiesPath = path.join(config.modRequest.platformProjectRoot, 'app', 'newrelic.properties');
+            fs.writeFileSync(propertiesPath, lines.join('\n') + '\n');
+            return config;
+        },
+    ]);
+};
+exports.withNewRelicMapUploadProperties = withNewRelicMapUploadProperties;

--- a/plugin/build/index.d.ts
+++ b/plugin/build/index.d.ts
@@ -4,5 +4,7 @@
  */
 import { ConfigPlugin } from '@expo/config-plugins';
 import { NewRelicPluginProps } from './android';
-declare const _default: ConfigPlugin<void | NewRelicPluginProps>;
+import { NewRelicIosPluginProps } from './ios';
+type CombinedNewRelicPluginProps = NewRelicPluginProps & NewRelicIosPluginProps;
+declare const _default: ConfigPlugin<void | CombinedNewRelicPluginProps>;
 export default _default;

--- a/plugin/build/index.d.ts
+++ b/plugin/build/index.d.ts
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0 
+ * SPDX-License-Identifier: Apache-2.0
  */
-
 import { ConfigPlugin } from '@expo/config-plugins';
-declare const _default: ConfigPlugin<void>;
+import { NewRelicPluginProps } from './android';
+declare const _default: ConfigPlugin<void | NewRelicPluginProps>;
 export default _default;

--- a/plugin/build/index.js
+++ b/plugin/build/index.js
@@ -1,9 +1,8 @@
+"use strict";
 /**
  * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0 
+ * SPDX-License-Identifier: Apache-2.0
  */
-
-"use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const android_1 = require("./android");
@@ -11,7 +10,12 @@ const projectPackage = require('newrelic-react-native-agent/package.json');
 /**
  * A config plugin for configuring `newrelic-react-native-agent`
  */
-const withNewRelicRNAgent = config => {
-    return (0, config_plugins_1.withPlugins)(config, [android_1.withBuildscriptDependency, android_1.withApplyNewRelicPlugin, android_1.withNetworkAcessPermission]);
+const withNewRelicRNAgent = (config, props) => {
+    return (0, config_plugins_1.withPlugins)(config, [
+        android_1.withBuildscriptDependency,
+        android_1.withApplyNewRelicPlugin,
+        android_1.withNetworkAcessPermission,
+        [android_1.withNewRelicMapUploadProperties, props !== null && props !== void 0 ? props : {}],
+    ]);
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withNewRelicRNAgent, projectPackage.name, projectPackage.version);

--- a/plugin/build/index.js
+++ b/plugin/build/index.js
@@ -6,6 +6,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("@expo/config-plugins");
 const android_1 = require("./android");
+const ios_1 = require("./ios");
 const projectPackage = require('newrelic-react-native-agent/package.json');
 /**
  * A config plugin for configuring `newrelic-react-native-agent`
@@ -16,6 +17,8 @@ const withNewRelicRNAgent = (config, props) => {
         android_1.withApplyNewRelicPlugin,
         android_1.withNetworkAcessPermission,
         [android_1.withNewRelicMapUploadProperties, props !== null && props !== void 0 ? props : {}],
+        ios_1.withNewRelicDsymUploadFiles,
+        [ios_1.withNewRelicDsymUploadBuildPhase, props !== null && props !== void 0 ? props : {}],
     ]);
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withNewRelicRNAgent, projectPackage.name, projectPackage.version);

--- a/plugin/build/ios/dsymUpload.d.ts
+++ b/plugin/build/ios/dsymUpload.d.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ConfigPlugin } from '@expo/config-plugins';
+export declare const defaultIosAppTokenEnvName = "NEWRELIC_IOS_APP_TOKEN";
+export declare const defaultIosApiKeyEnvName = "NEWRELIC_USER_API_KEY";
+export type NewRelicIosPluginProps = {
+    ios?: {
+        /**
+         * Name of the environment variable containing the iOS application token (the same
+         * token passed to `NewRelic.startAgent()` on iOS). Used by both the dSYM upload and
+         * the React Native source map upload build phase scripts.
+         * Defaults to `NEWRELIC_IOS_APP_TOKEN`.
+         */
+        appTokenEnvName?: string;
+        /**
+         * Name of the environment variable containing the New Relic User/Ingest API key.
+         * Only used by the React Native source map upload script.
+         * Defaults to `NEWRELIC_USER_API_KEY` (shared with the Android default).
+         */
+        apiKeyEnvName?: string;
+    };
+};
+/**
+ * Copy the vendored `dsym-upload-tools` scripts into `ios/dsym-upload-tools`, since that
+ * directory is regenerated on every prebuild (locally and on EAS Build).
+ */
+export declare const withNewRelicDsymUploadFiles: ConfigPlugin;
+/**
+ * Add a Run Script build phase (after "Bundle React Native code and images") that invokes
+ * the vendored dSYM and React Native source map upload scripts, and ensure the bundle
+ * phase exports SOURCEMAP_FILE so a source map actually gets generated for the script to
+ * find. Both additions are idempotent across repeated prebuilds.
+ */
+export declare const withNewRelicDsymUploadBuildPhase: ConfigPlugin<NewRelicIosPluginProps>;

--- a/plugin/build/ios/dsymUpload.js
+++ b/plugin/build/ios/dsymUpload.js
@@ -1,0 +1,120 @@
+"use strict";
+/**
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withNewRelicDsymUploadBuildPhase = exports.withNewRelicDsymUploadFiles = exports.defaultIosApiKeyEnvName = exports.defaultIosAppTokenEnvName = void 0;
+const fs = __importStar(require("fs"));
+const path = __importStar(require("path"));
+const config_plugins_1 = require("@expo/config-plugins");
+exports.defaultIosAppTokenEnvName = 'NEWRELIC_IOS_APP_TOKEN';
+exports.defaultIosApiKeyEnvName = 'NEWRELIC_USER_API_KEY';
+const VENDORED_TOOLS_DIR = path.join(__dirname, '..', '..', 'dsym-upload-tools');
+const TOOLS_SUBDIR_NAME = 'dsym-upload-tools';
+const BUILD_PHASE_NAME = 'Upload dSYMs and Source Maps to New Relic';
+const BUNDLE_PHASE_NAME = 'Bundle React Native code and images';
+const SOURCEMAP_FILE_EXPORT_LINE = 'export SOURCEMAP_FILE="$DERIVED_FILE_DIR/main.jsbundle.map"';
+/**
+ * Copy the vendored `dsym-upload-tools` scripts into `ios/dsym-upload-tools`, since that
+ * directory is regenerated on every prebuild (locally and on EAS Build).
+ */
+const withNewRelicDsymUploadFiles = config => {
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        'ios',
+        config => {
+            const destDir = path.join(config.modRequest.platformProjectRoot, TOOLS_SUBDIR_NAME);
+            fs.mkdirSync(destDir, { recursive: true });
+            for (const file of fs.readdirSync(VENDORED_TOOLS_DIR)) {
+                const srcPath = path.join(VENDORED_TOOLS_DIR, file);
+                const destPath = path.join(destDir, file);
+                fs.copyFileSync(srcPath, destPath);
+                fs.chmodSync(destPath, fs.statSync(srcPath).mode);
+            }
+            return config;
+        },
+    ]);
+};
+exports.withNewRelicDsymUploadFiles = withNewRelicDsymUploadFiles;
+function unwrapShellScript(raw) {
+    const trimmed = raw.startsWith('"') && raw.endsWith('"') ? raw.slice(1, -1) : raw;
+    return trimmed.replace(/\\"/g, '"').replace(/\\n/g, '\n');
+}
+function wrapShellScript(text) {
+    return '"' + text.replace(/"/g, '\\"').replace(/\n/g, '\\n') + '"';
+}
+function buildUploadScript(appTokenEnvName, apiKeyEnvName) {
+    return [
+        'ARTIFACT_DIR="${BUILD_DIR%Build/*}"',
+        '',
+        `if [ -n "$${appTokenEnvName}" ]; then`,
+        '  DSYM_SCRIPT=$(/usr/bin/find "${SRCROOT}" "${ARTIFACT_DIR}" -type f -name run-symbol-tool | head -n 1)',
+        '  if [ -n "$DSYM_SCRIPT" ]; then',
+        `    /bin/sh "$DSYM_SCRIPT" "$${appTokenEnvName}"`,
+        '  fi',
+        'else',
+        `  echo "New Relic: ${appTokenEnvName} not set, skipping dSYM upload"`,
+        'fi',
+        '',
+        `if [ -n "$${apiKeyEnvName}" ] && [ -n "$${appTokenEnvName}" ]; then`,
+        '  SOURCEMAP_SCRIPT=$(/usr/bin/find "${SRCROOT}" "${ARTIFACT_DIR}" -type f -name upload-react-native-sourcemap | head -n 1)',
+        '  if [ -n "$SOURCEMAP_SCRIPT" ]; then',
+        `    /bin/sh "$SOURCEMAP_SCRIPT" "$${apiKeyEnvName}" "$${appTokenEnvName}"`,
+        '  fi',
+        'else',
+        `  echo "New Relic: ${apiKeyEnvName} or ${appTokenEnvName} not set, skipping source map upload"`,
+        'fi',
+        '',
+        'exit 0',
+    ].join('\n');
+}
+/**
+ * Add a Run Script build phase (after "Bundle React Native code and images") that invokes
+ * the vendored dSYM and React Native source map upload scripts, and ensure the bundle
+ * phase exports SOURCEMAP_FILE so a source map actually gets generated for the script to
+ * find. Both additions are idempotent across repeated prebuilds.
+ */
+const withNewRelicDsymUploadBuildPhase = (config, props = {}) => {
+    var _a, _b, _c, _d;
+    const appTokenEnvName = (_b = (_a = props.ios) === null || _a === void 0 ? void 0 : _a.appTokenEnvName) !== null && _b !== void 0 ? _b : exports.defaultIosAppTokenEnvName;
+    const apiKeyEnvName = (_d = (_c = props.ios) === null || _c === void 0 ? void 0 : _c.apiKeyEnvName) !== null && _d !== void 0 ? _d : exports.defaultIosApiKeyEnvName;
+    return (0, config_plugins_1.withXcodeProject)(config, config => {
+        const project = config.modResults;
+        const bundlePhase = project.buildPhaseObject('PBXShellScriptBuildPhase', BUNDLE_PHASE_NAME);
+        if (bundlePhase) {
+            const script = unwrapShellScript(bundlePhase.shellScript);
+            if (!script.includes('SOURCEMAP_FILE=')) {
+                bundlePhase.shellScript = wrapShellScript(`${SOURCEMAP_FILE_EXPORT_LINE}\n${script}`);
+            }
+        }
+        const existingPhase = project.buildPhaseObject('PBXShellScriptBuildPhase', BUILD_PHASE_NAME);
+        if (!existingPhase) {
+            project.addBuildPhase([], 'PBXShellScriptBuildPhase', BUILD_PHASE_NAME, project.getFirstTarget().uuid, { shellPath: '/bin/sh', shellScript: buildUploadScript(appTokenEnvName, apiKeyEnvName) });
+        }
+        return config;
+    });
+};
+exports.withNewRelicDsymUploadBuildPhase = withNewRelicDsymUploadBuildPhase;

--- a/plugin/build/ios/dsymUpload.js
+++ b/plugin/build/ios/dsymUpload.js
@@ -112,7 +112,13 @@ const withNewRelicDsymUploadBuildPhase = (config, props = {}) => {
         }
         const existingPhase = project.buildPhaseObject('PBXShellScriptBuildPhase', BUILD_PHASE_NAME);
         if (!existingPhase) {
-            project.addBuildPhase([], 'PBXShellScriptBuildPhase', BUILD_PHASE_NAME, project.getFirstTarget().uuid, { shellPath: '/bin/sh', shellScript: buildUploadScript(appTokenEnvName, apiKeyEnvName) });
+            const { buildPhase } = project.addBuildPhase([], 'PBXShellScriptBuildPhase', BUILD_PHASE_NAME, project.getFirstTarget().uuid, { shellPath: '/bin/sh', shellScript: buildUploadScript(appTokenEnvName, apiKeyEnvName) });
+            // Without declared inputs/outputs, Xcode's new build system warns that the script
+            // "has ambiguous dependencies causing it to run on every build". We DO want it to
+            // run on every Release build, so explicitly mark it always-out-of-date (equivalent
+            // to unchecking "Based on dependency analysis" in Xcode) rather than declaring
+            // outputPaths, which could make a later build with unchanged inputs skip it.
+            buildPhase.alwaysOutOfDate = 1;
         }
         return config;
     });

--- a/plugin/build/ios/index.d.ts
+++ b/plugin/build/ios/index.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { withNewRelicDsymUploadFiles, withNewRelicDsymUploadBuildPhase, NewRelicIosPluginProps, defaultIosAppTokenEnvName, defaultIosApiKeyEnvName } from './dsymUpload';
+export { withNewRelicDsymUploadFiles, withNewRelicDsymUploadBuildPhase, NewRelicIosPluginProps, defaultIosAppTokenEnvName, defaultIosApiKeyEnvName, };

--- a/plugin/build/ios/index.js
+++ b/plugin/build/ios/index.js
@@ -1,0 +1,12 @@
+"use strict";
+/**
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.defaultIosApiKeyEnvName = exports.defaultIosAppTokenEnvName = exports.withNewRelicDsymUploadBuildPhase = exports.withNewRelicDsymUploadFiles = void 0;
+const dsymUpload_1 = require("./dsymUpload");
+Object.defineProperty(exports, "withNewRelicDsymUploadFiles", { enumerable: true, get: function () { return dsymUpload_1.withNewRelicDsymUploadFiles; } });
+Object.defineProperty(exports, "withNewRelicDsymUploadBuildPhase", { enumerable: true, get: function () { return dsymUpload_1.withNewRelicDsymUploadBuildPhase; } });
+Object.defineProperty(exports, "defaultIosAppTokenEnvName", { enumerable: true, get: function () { return dsymUpload_1.defaultIosAppTokenEnvName; } });
+Object.defineProperty(exports, "defaultIosApiKeyEnvName", { enumerable: true, get: function () { return dsymUpload_1.defaultIosApiKeyEnvName; } });

--- a/plugin/dsym-upload-tools/run-symbol-tool
+++ b/plugin/dsym-upload-tools/run-symbol-tool
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# 2022 New Relic
+# Shell wrapper script used to upload a builds debug symbols to New Relic.
+# run-symbol-tool 
+
+if [ ! $1 ]; then
+    echo "New Relic: usage: $0 <NEW_RELIC_APP_TOKEN> [--debug] [-appVersion <version>]"
+    exit -1
+fi
+
+API_KEY=$1
+# Consume the app token and forward any remaining optional arguments (--debug, -appVersion <version>)
+# to the Swift script verbatim. Using "$@" preserves quoting so a version value with spaces is safe.
+shift
+
+echo "New Relic: Processing dSYMs and uploading to New Relic. (In background...)"
+echo "New Relic: For troubleshooting, see upload_dsym_results.log file in project root folder. Add --debug after app token in Run Script for additional information."
+
+WORK_DIRECTORY=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+SCRIPT="$WORK_DIRECTORY/run-symbol-tool.swift"
+
+## Running with below command is useful for seeing output in Xcode,
+## but it will incur delays in the build process while the dSYMs process and upload.
+# /usr/bin/xcrun --sdk macosx swift "$SCRIPT" "$API_KEY" "$@"
+
+/usr/bin/xcrun --sdk macosx swift "$SCRIPT" "$API_KEY" "$@" > upload_dsym_results.log 2>&1 &

--- a/plugin/dsym-upload-tools/run-symbol-tool.swift
+++ b/plugin/dsym-upload-tools/run-symbol-tool.swift
@@ -1,0 +1,642 @@
+//
+//  run-symbol-tool.swift
+//  2022 New Relic
+//
+// Swift script used to upload a builds symbols to New Relic.
+// Intended to be run from a Xcode build phase.
+//
+// 1. In Xcode, select your project in the navigator, then click on the application target.
+// 2. Select the Build Phases tab in the settings editor.
+// 3. Click the + icon above Target Dependencies and choose New Run Script Build Phase.
+// 4. Add the following lines of code to the new phase, pasting in the
+//     application token as "APP_TOKEN" from your New Relic dashboard for the app in question.
+// 
+// ```
+//  SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+//  /bin/sh "${SCRIPT}" "APP_TOKEN"
+// ```
+//
+// Optional:
+//
+// Add "--debug" after script invocation to enable debug logs in the output upload_dsym_results.log file.
+//
+// ```
+//  SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+//  /bin/sh "${SCRIPT}" "APP_TOKEN" --debug
+// ```
+//
+// Optional: pass "-appVersion" to set the reported app version (X-NewRelic-App-Version) explicitly.
+// Use this when MARKETING_VERSION is unset or empty (e.g. apps versioned with agvtool, or
+// multi-target apps that set GENERATE_INFOPLIST_FILE = YES). App version precedence:
+//   -appVersion arg  >  NEWRELIC_APP_VERSION env  >  MARKETING_VERSION env  >  default.
+//
+// ```
+//  SCRIPT=`/usr/bin/find "${SRCROOT}/../.." -name run-symbol-tool | head -n 1`
+//  /bin/sh "${SCRIPT}" "APP_TOKEN" -appVersion "7.8.2"
+// ```
+//
+// DSYM_UPLOAD_URL - define this environment variable above run script to override the New Relic server hostname
+//
+// - Due to limitations with Swift scripting run-symbol-tool.swift is one file.
+//   Main script contents are in start() func. Helper functions are categorized at the end.
+// - Script will first attempt to convert each dSYM into NR map files, 
+//   then it will combine map files into zip file and upload to New Relic.
+//   If conversion isn't possible or zipped map files upload fails the dSYMs are uploaded to New Relic.
+// ============================================================================
+// START of Script run-symbol-tool.swift
+import Foundation
+
+let defaultURL = "https://mobile-symbol-upload.newrelic.com"
+let fileManager = FileManager.default
+let environment = ProcessInfo.processInfo.environment
+// Set to true for additional debug info in the upload_dsym_results.log file.
+var debug = false
+// Set to true for dSYM upload feature. (dSYM files are normally only uploaded if map file conversion fails.)
+let uploadDsymsOnly = false
+
+var symbolEndpointPath = "map"
+var dsymEndpointPath   = "symbol"
+var symbolUploadDataPostKey = "upload"
+var dsymUploadDataPostKey   = "dsym"
+
+// Agent version number.
+var versionNumber = "7.4.12"
+var osName = "iOS"
+var platformName = "Native"
+var appVersionNumber = "1.2.3"
+
+// Maximum zipped source map size (in bytes) before falling back to telemetry upload (200 MB).
+let sourceMapSizeThreshold: UInt64 = 209_715_200
+
+enum SymbolToolError: Error {
+    case failedToConvert
+    case failedToUpload
+}
+
+start()
+
+func start() {
+    print("New Relic: Starting dSYM upload script...")
+
+    let isBitcodeEnabled = environment["ENABLE_BITCODE"] == "YES"
+    guard !isBitcodeEnabled else {
+        print("New Relic: Build is Bitcode enabled. No dSYM has been uploaded. Bitcode enabled apps require dSYM files to be downloaded from App Store Connect. For more information please review https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/retrieve-upload-dsyms  Exiting without failure.")
+        exit(0)
+    }
+
+    let directory = environment["DWARF_DSYM_FOLDER_PATH"]
+    let platformName = environment["EFFECTIVE_PLATFORM_NAME"]
+
+    if platformName == "-iphonesimulator" {
+        print("New Relic: Skipping automatic upload of simulator build symbols")
+        exit(0)
+    }
+
+    guard CommandLine.arguments.count > 1 else {
+        // Must contain at least one argument: $APP_TOKEN. (--debug and -appVersion are optional)
+        print("Invalid Usage: Ex: Swift: run-symbol-tool.swift $APP_TOKEN [--debug] [-appVersion <version>]")
+        exit(1)
+    }
+    let apiKey = CommandLine.arguments[1]
+    
+    // Optional CLI app-version override (e.g. -appVersion 7.8.2). Takes precedence over MARKETING_VERSION.
+    // NR-417639: agvtool / multi-target apps often leave MARKETING_VERSION unset or empty.
+    var appVersionOverride: String? = nil
+
+    // Parse the remaining optional arguments in an order-independent way so that --debug and
+    // -appVersion can appear in any order (and future flags can be added without breaking parsing).
+    let arguments = CommandLine.arguments
+    var argIndex = 2
+    while argIndex < arguments.count {
+        let arg = arguments[argIndex]
+        switch arg {
+        case "--debug":
+            debug = true
+        case "-appVersion", "--appVersion", "--app-version":
+            guard argIndex + 1 < arguments.count else {
+                print("New Relic: Invalid Usage: \(arg) requires a value, e.g. -appVersion 7.8.2. Exiting.")
+                exit(1)
+            }
+            argIndex += 1
+            appVersionOverride = arguments[argIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+        default:
+            print("New Relic: Ignoring unrecognized argument: \(arg)")
+        }
+        argIndex += 1
+    }
+
+// Start Configure Env Vars //
+    /// Grab URLs and Keys from environment variables. 
+    // Grab URL from set Env Var "$DSYM_UPLOAD_URL" or use default URL.
+    var url = environment["DSYM_UPLOAD_URL"] ?? defaultURL
+    symbolEndpointPath = environment["NEWRELIC_SYMBOL_ENDPOINT"] ?? "map"
+    dsymEndpointPath   = environment["NEWRELIC_DSYM_ENDPOINT"] ?? "symbol"
+
+    symbolUploadDataPostKey = environment["NEWRELIC_SYMBOL_POST_KEY"] ?? "upload"
+    dsymUploadDataPostKey   = environment["NEWRELIC_DSYM_POST_KEY"] ?? "dsym"
+
+    // App-version precedence: -appVersion arg > NEWRELIC_APP_VERSION env > MARKETING_VERSION env > default.
+    // Each source is treated as unresolved when empty so a present-but-empty MARKETING_VERSION
+    // no longer produces an empty X-NewRelic-App-Version header. (NR-417639)
+    if let overrideVersion = appVersionOverride, !overrideVersion.isEmpty {
+        appVersionNumber = overrideVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: -appVersion argument)")
+    } else if let envAppVersion = environment["NEWRELIC_APP_VERSION"], !envAppVersion.isEmpty {
+        appVersionNumber = envAppVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: NEWRELIC_APP_VERSION)")
+    } else if let marketingVersion = environment["MARKETING_VERSION"], !marketingVersion.isEmpty {
+        appVersionNumber = marketingVersion
+        print("New Relic: Using app version \(appVersionNumber) (source: MARKETING_VERSION)")
+    } else {
+        // No usable app version was found. Symbols would otherwise be tagged with a placeholder
+        // that will not match real builds, so warn loudly instead of failing silently. (NR-417639)
+        print("New Relic: WARNING - No app version found (MARKETING_VERSION is unset/empty and no -appVersion argument was provided). Using placeholder \"\(appVersionNumber)\"; uploaded symbol maps may not match your build's version. Pass -appVersion <version> or set MARKETING_VERSION / NEWRELIC_APP_VERSION.")
+    }
+// End Configure Env Vars //
+
+
+    if let regionAwareURL = parseRegionFromApiKey(apiKey) {
+        url = regionAwareURL
+        print("**** Using Region Aware URL: \(url)")
+    }
+
+    if debug {
+        print("========== dSYM directory = \(directory ?? "NOT FOUND")")
+        print("========== Platform = \(platformName ?? "NOT FOUND")")
+        print("========== URL = \(url)")
+        print("========== apiKey = \(apiKey)")
+    }
+
+    guard let directory = directory else { 
+        print("No directory to work on. ($DWARF_DSYM_FOLDER_PATH) Exiting.")
+        exit(1)
+    }
+
+    var dSYMPaths = [String]()
+    do {
+        let contents = try fileManager.contentsOfDirectory(atPath: directory)
+        for content in contents where content.hasSuffix(".dSYM") {
+            // Was previously...
+//            dSYMPaths.append("\(directory)/\(content)")
+// Now we are using the following code based on a fix suggested to us.  
+            let dwarfContents = try fileManager.contentsOfDirectory(atPath: "\(directory)/\(content)/Contents/Resources/DWARF")
+            for dwarfContent in dwarfContents {        
+                dSYMPaths.append("\(directory)/\(content)/Contents/Resources/DWARF/\(dwarfContent)") 
+            }
+        }
+    } catch {
+        print(error)
+        print("Error: We've encountered an error opening the dSYM directory. Exiting.")
+        exit(1)
+    }
+    
+    if debug { print("dSYMs located at: \(dSYMPaths)") }
+    guard !dSYMPaths.isEmpty else {
+        print("Error: No dSYMs found to process. Make sure your Xcode project target build setting 'Debug Information Format' is set to 'DWARF with dSYM File'.  Exiting.")
+        exit(1)
+    }
+    // Attempt to convert each dSYM to a New Relic map file. If an error is encountered during conversion or map upload the dSYMs will be uploaded.
+    for debugSymbolPath in dSYMPaths {
+        func fallback() {
+            print("Falling back to upload zipped dSYM...")
+            do {
+                try zipAndUploadDsym(debugSymbolPath, apiKey, url)
+            } catch {
+                print(error)
+            }
+        }
+
+        if uploadDsymsOnly {
+            print("*** uploadDsymsOnly is set to true. Performing dSYM upload...")
+            fallback()
+            continue
+        }
+
+        // If dSYM fails to be converted to map file we skip to upload the dSYM.
+        do {
+            try processDsym(debugSymbolPath, apiKey, url)
+        } catch {
+            print("Error in conversion: \(error) encountered processing dSYM at path: \(debugSymbolPath)")
+            // Fallback to upload the dSYM due to error encountered processing dSYM->Map or uploading map.
+            fallback()
+        }
+    }
+}
+// END of Script run-symbol-tools.swift
+// ============================================================================
+
+func zipAndUploadDsym(_ dsymPath: String, _ apiKey: String, _ url: String) throws {
+    guard let tempDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+        throw SymbolToolError.failedToConvert
+    }
+    
+    let tempDirURL = tempDir.appendingPathComponent("\(UUID())")    
+    try fileManager.createDirectory(at: tempDirURL, withIntermediateDirectories: true)
+    let dsymUrl = URL(fileURLWithPath: dsymPath)
+    let newURL = tempDirURL.appendingPathComponent(dsymUrl.lastPathComponent)
+    try fileManager.copyItem(at: dsymUrl, to: newURL)
+        
+    // Now that the dSYM file is in tempDirURL dir lets zip it up.
+    let coordinator = NSFileCoordinator()
+    var zipError: NSError?
+    var archiveUrl: URL?
+
+    coordinator.coordinate(readingItemAt: tempDirURL, options: .forUploading, error: &zipError) { zipURL in
+        do {
+            let temporaryURL =  tempDirURL.appendingPathComponent("dsymArchive.zip")
+            try fileManager.copyItem(at: zipURL, to: temporaryURL)
+            archiveUrl = temporaryURL
+
+            if let archiveUrl = archiveUrl {
+
+                print("successfully zipped dSYM to \(archiveUrl)")
+
+                // get size @ archiveUrl 
+                guard let size = getSizeAtURL(archiveUrl) else { 
+                    print("Failed to get fileSize. --failing")
+                    return 
+                }
+                if debug {
+                    print("Detected zipped dSYM file size = \(size). Uploading...")
+                }
+                // Now that we have archiveUrl with the dSYM file zipped up, upload the zip file.
+                let dsymUploadResult = try uploadFile(archiveUrl.path, apiKey, url, true, size)
+                if dsymUploadResult == "201" {
+                    print("Successfully uploaded dSYM: \(archiveUrl.path)")
+                }
+                else {
+                    print("*** Failed w/ error: \(dsymUploadResult ?? "NO ERROR") when upload dSYM: \(archiveUrl.path)")
+                }
+                // Remove copied dSYM and zipped dSYM and temporary folder.
+                try fileManager.removeItem(at: tempDirURL)
+            }
+        }
+        catch {
+            print(error)
+        }
+    }
+}
+
+// Helper Functions
+func processDsym(_ path: String, _ apiKey: String, _ url: String) throws {
+    var resultFromSymbolsUUID: String? = nil
+    do {
+        if debug { print("Executing $ symbols -uuid '\(path)'") }
+        resultFromSymbolsUUID = try shell("symbols -uuid '\(path)'")
+    } catch {
+        print("\(error) running symbols --uuid. Exiting.")
+        throw SymbolToolError.failedToConvert
+    }
+    guard let resultFromSymbolsUUID = resultFromSymbolsUUID else {
+        print("`symbols -uuid` Result is nil. Exiting.")
+        throw SymbolToolError.failedToConvert
+    }
+
+    if debug { print("result from symbols --uuid: \(resultFromSymbolsUUID)") }
+    var uuidDict = [String: String]()
+    let lines = resultFromSymbolsUUID.split(whereSeparator: \.isNewline)
+    for line in lines where !line.isEmpty {
+        let parts = line.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: " ")
+        if parts.count > 1  {
+            let uuid = parts[0].lowercased().replacingOccurrences(of: "-", with: "").trimmingCharacters(in: .whitespaces)
+            let arch = parts[1].trimmingCharacters(in: .whitespaces)
+            uuidDict[uuid] = arch
+        }
+        else {
+            print("failed to parse parts of \(line)")
+            throw SymbolToolError.failedToConvert
+        }
+    }
+    if debug { print("Parsed uuids: \(uuidDict)") }
+
+    var mapURLs = [URL]()
+    for (key, value) in uuidDict {
+        var resultFromSymbolsArch: String? = nil
+        do {
+            if debug { print("Executing $ symbols -arch \(value) '\(path)'") }
+            resultFromSymbolsArch = try shell("symbols -arch \(value) '\(path)'")
+        } catch {
+            print("\(error). Exiting dSYM conversion process.")
+            throw SymbolToolError.failedToConvert
+        }
+        guard let resultFromSymbolsArch = resultFromSymbolsArch else {
+            print("symbols -arch` Result is nil. Exiting dSYM conversion process.")
+            throw SymbolToolError.failedToConvert
+        }
+        
+        do {
+            let url = try processSymbolsOutput(resultFromSymbolsArch, key, value)
+            mapURLs.append(url)
+        } catch {
+            print("\(error). Exiting dSYM conversion process.")
+            throw SymbolToolError.failedToConvert
+        }
+    }
+    if debug { print("Parsed mapFiles: \(mapURLs)") }
+
+    // Zip up all map files produced by symbol processing.
+    guard let tempDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+        throw SymbolToolError.failedToConvert
+    }
+    
+    let tempDirURL = tempDir.appendingPathComponent("\(UUID())")
+    
+    try fileManager.createDirectory(at: tempDirURL, withIntermediateDirectories: true)
+    // move files in mapURLs into a temporary directory
+    for mapFile in mapURLs {
+        let newURL = tempDirURL.appendingPathComponent(mapFile.lastPathComponent)
+        try fileManager.moveItem(at: mapFile, to: newURL)
+    }
+
+    // Now that the map files are in tempDirURL dir lets zip it up.
+    let coordinator = NSFileCoordinator()
+    var zipError: NSError?
+    var archiveUrl: URL?
+
+    coordinator.coordinate(readingItemAt: tempDirURL, options: .forUploading, error: &zipError) { zipURL in
+        do {
+            let temporaryURL =  tempDirURL.appendingPathComponent("mapArchive.zip")
+            try fileManager.moveItem(at: zipURL, to: temporaryURL)
+            archiveUrl = temporaryURL
+
+            if let archiveUrl = archiveUrl {
+
+                // get size @ archiveUrl
+                guard let size = getSizeAtURL(archiveUrl) else {
+                    print("Failed to get fileSize. --failing")
+                    return
+                }
+                if debug {
+                    print("Detected zipped map file size = \(size).")
+                }
+
+                // Check if the zipped source map exceeds the 200MB upload threshold.
+                // Because source maps are highly compressible, only the zipped size is evaluated.
+                if size > sourceMapSizeThreshold {
+                    // File is too large to upload directly; send telemetry metadata instead.
+                    if debug { print("Zipped map (\(size) bytes) exceeds 200MB threshold. Using telemetry fallback.") }
+                    let telemetryResult = try uploadViaTelemetry(archiveUrl.path, apiKey, url, size)
+                    if telemetryResult == "200" || telemetryResult == "201" {
+                        print("Successfully sent telemetry for oversized map: \(archiveUrl.path)")
+                    } else {
+                        print("*** Failed w/ error: \(telemetryResult ?? "NO ERROR") sending telemetry for \(archiveUrl.path)")
+                    }
+                } else {
+                    if debug { print("Uploading zipped map file (\(size) bytes)...") }
+                    // Now that we have archiveUrl with the combined map files zipped up, upload the map file.
+                    let mapUploadResult = try uploadFile(archiveUrl.path, apiKey, url, false, size)
+                    if mapUploadResult == "201" {
+                        print("Successfully uploaded map: \(archiveUrl.path)")
+                    } else {
+                        print("*** Failed w/ error: \(mapUploadResult ?? "NO ERROR") when upload \(archiveUrl.path)")
+                    }
+                }
+
+                // Remove moved map file, zipped map file, and temporary folder.
+                try fileManager.removeItem(at: tempDirURL)
+            }
+        } catch {
+            print(error)
+        }
+    }
+}
+
+func processSymbolsOutput(_ symbolsOutput: String, _ key: String, _ value: String) throws -> URL {
+    let vmAddressOffset = 8
+    let dwarfAddressOffset = 12
+    let functionOffset = 16
+    let sourceLineOffset = 20
+
+    var vmAddresses = [String]()
+    var symbols = [String: String]()
+
+    if debug { print("Processing symbols output...") }
+
+    let lines = symbolsOutput.split(whereSeparator: \.isNewline)
+    var currentFunction = ""
+    for line in lines where !line.isEmpty {
+        let whitespaceEndIndex = line.firstIndex(where: { !CharacterSet(charactersIn: String($0)).isSubset(of: .whitespaces) })
+        let whitespaceCount: Int
+        if let whitespaceEndIndex = whitespaceEndIndex {
+            whitespaceCount = line.distance(from: line.startIndex, to: whitespaceEndIndex)
+        }
+        else {
+            whitespaceCount = 0
+        }
+        let strippedLine = line.trimmingCharacters(in: .whitespaces)
+        switch whitespaceCount {
+        case vmAddressOffset:
+            let vmAddress = try parseVmAddress(strippedLine)
+            vmAddresses.append(vmAddress)
+        case dwarfAddressOffset:
+            if let dwarfSymbol = try parseDwarf(strippedLine) {
+                symbols[dwarfSymbol.0] = dwarfSymbol.1
+            }
+        case functionOffset:
+            let funcSymbol = try parseFunction(strippedLine)
+            // Update the current function being parsed. This is used when constructing source line symbols.
+            currentFunction = funcSymbol.1
+            symbols[funcSymbol.0] = funcSymbol.1
+        case sourceLineOffset:
+            let sourceLineSymbol = try parseSourceLine(strippedLine, currentFunction)
+            symbols[sourceLineSymbol.0] = sourceLineSymbol.1
+        default:
+            break
+        }
+    }
+    if debug { print("Successfully processed symbols output. COUNT: \(vmAddresses.count) VM, \(symbols.count) SYM") }
+
+    var mapFileContents = ""
+    mapFileContents.append("# uuid \(key.uppercased())\n")
+    mapFileContents.append("# architecture \(value)\n")
+    // Add sorted vmAddresses
+    for vmAddress in vmAddresses.sorted() {
+        let vmAddrLine = "# vmaddr \(vmAddress)\n"
+        mapFileContents.append(vmAddrLine)
+    }
+    // Add sorted symbols
+    for key in symbols.keys.sorted() {
+        if let symbolValue = symbols[key] {
+            let symbolLine = "\(key) \(symbolValue)\n"
+            mapFileContents.append(symbolLine)
+        }
+    }
+    // Now that the map file contents are in mapFileContents. Write it out to map file in the caches directory.
+    guard let tempDir = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+        throw SymbolToolError.failedToConvert
+    }
+    
+    let fileURL = tempDir.appendingPathComponent("\(key).map")
+    do {
+        try mapFileContents.write(to: fileURL, atomically: false, encoding: .utf8)
+        if debug { print("Map file successfully saved to \(fileURL)") }
+        return fileURL
+    } catch {
+        print(error)
+        throw SymbolToolError.failedToConvert
+    }
+}
+
+// dSYM Parsing utilities
+func parseVmAddress(_ line: String) throws -> String {
+    guard let vmAddress = line.components(separatedBy: " ").first?.uppercased() else {
+        print("Found invalid vm address. Exiting map file conversion.")
+        throw SymbolToolError.failedToConvert
+    }
+    return padHex(vmAddress)
+}
+
+func parseDwarf(_ line: String) throws -> (String, String)? {
+    guard let closeParen = line.firstIndex(of: ")") else {
+        print("Found invalid DWARF symbol. Exiting map file conversion.")
+        throw SymbolToolError.failedToConvert
+    }
+    let closeParenIndex = line.index(closeParen, offsetBy: 2)
+    guard let openParen = line.firstIndex(of: "(") else {
+        print("Found invalid DWARF symbol. Exiting map file conversion.")
+        throw SymbolToolError.failedToConvert
+    }
+    let openParenIndex = line.index(openParen, offsetBy: 0)
+    let symbolString = line[closeParenIndex...].trimmingCharacters(in: .whitespaces)
+
+    guard symbolString.range(of: "__DWARF") != nil else {
+        return nil
+    }
+    let returnKey = padHex(String(line[...openParenIndex]))
+    guard let returnValue = symbolString.components(separatedBy: " ").last else {
+        print("Found invalid DWARF symbol. Exiting map file conversion.")
+        throw SymbolToolError.failedToConvert
+    }
+    return (returnKey, returnValue)
+}
+
+func parseFunction(_ line: String) throws -> (String, String) {
+    guard let closeParen = line.firstIndex( of: ")"),
+          let openParen = line.firstIndex( of: "(") else {
+        print("Found invalid FUNCTION symbol. Exiting map file conversion.")
+        throw SymbolToolError.failedToConvert
+    }
+    let closeParenIndex = line.index(closeParen, offsetBy: 1)
+    let openParenIndex = line.index(openParen, offsetBy: 0)
+    var currentFunction = ""
+    if let bracket = line.range(of: " [") {
+        let bracketIndex = line.index(bracket.lowerBound, offsetBy: 0)
+        currentFunction = String(line[closeParenIndex...bracketIndex])
+    }
+    else {
+        currentFunction = String(line[closeParenIndex...]).trimmingCharacters(in: .whitespaces) + " "
+    }
+
+    return (padHex(String(line[...openParenIndex])), currentFunction)
+}
+
+func parseSourceLine(_ line: String, _ currentFunction: String) throws -> (String, String) {
+    let lineSplit = line.components(separatedBy: " ").filter { !$0.isEmpty }
+    guard lineSplit.count > 3 else {
+        print("Found invalid SOURCE LINE symbol. Exiting map file conversion.")
+        throw SymbolToolError.failedToConvert
+    }
+    let sourceString = "\(currentFunction.trimmingCharacters(in: .whitespaces)) (\(lineSplit[3]))"
+
+    return (padHex(lineSplit[0]), sourceString)
+}
+
+func padHex(_ hexString: String) -> String {
+     let subHexString = String(hexString.dropFirst(2))
+     let filledSubHexString = subHexString.padding(toLength: 16, withPad: "0", startingAt: 0)
+     return "0x\(filledSubHexString)"
+ }
+
+// Networking via curl
+func uploadFile(_ path: String, _ apiKey: String, _ url: String, _ isDsym: Bool, _ size: UInt64) throws -> String? {
+    var resultFromCurl: String? = nil
+    do {
+        let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? dsymUploadDataPostKey : symbolUploadDataPostKey)=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" -H \"X-NewRelic-Agent-Version: \(versionNumber)\" -H \"X-NewRelic-OS-Name: \(osName)\" -H \"X-NewRelic-Platform: \(platformName)\" -H \"X-NewRelic-App-Version: \(appVersionNumber)\" -H \"X-File-Size: \(size)\" \(url)/\(isDsym ? dsymEndpointPath : symbolEndpointPath)"
+
+       // let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -F \(isDsym ? "dsym" : "upload")=@\"\(path)\" -H \"x-app-license-key: \(apiKey)\" -H \"Content-Disposition: attachment\" -H \"X-File-Size: \(size)\" \(url)/\(isDsym ? "symbol" : "map")"
+
+
+        if debug { print("Executing $ \(command)") }
+        resultFromCurl = try shell(command)
+    } catch {
+        print("curl \(error). Exiting upload process.")
+        throw SymbolToolError.failedToUpload
+    }
+
+    return resultFromCurl
+}
+
+// Telemetry fallback: sends a Base64-encoded JSON metadata payload via the x-telemetry-data header
+// instead of uploading the source map file directly. Used when the zipped map exceeds 200MB.
+func uploadViaTelemetry(_ path: String, _ apiKey: String, _ url: String, _ size: UInt64) throws -> String? {
+    var resultFromCurl: String? = nil
+    do {
+        let jsonString = "{\"type\":\"sourcemap\",\"size\":\(size),\"appVersion\":\"\(appVersionNumber)\",\"agentVersion\":\"\(versionNumber)\",\"osName\":\"\(osName)\",\"platform\":\"\(platformName)\",\"reason\":\"file_size_exceeded\"}"
+        guard let jsonData = jsonString.data(using: .utf8) else {
+            print("Failed to encode telemetry JSON.")
+            throw SymbolToolError.failedToUpload
+        }
+        let telemetryB64 = jsonData.base64EncodedString()
+
+        let command = "curl --retry 3 --write-out %{http_code} --silent --output /dev/null -H \"x-app-license-key: \(apiKey)\" -H \"X-NewRelic-Agent-Version: \(versionNumber)\" -H \"X-NewRelic-OS-Name: \(osName)\" -H \"X-NewRelic-Platform: \(platformName)\" -H \"X-NewRelic-App-Version: \(appVersionNumber)\" -H \"X-File-Size: \(size)\" -H \"x-telemetry-data: \(telemetryB64)\" \(url)/\(symbolEndpointPath)"
+
+        if debug { print("Executing $ \(command)") }
+        resultFromCurl = try shell(command)
+    } catch {
+        print("curl telemetry \(error). Exiting upload process.")
+        throw SymbolToolError.failedToUpload
+    }
+    return resultFromCurl
+}
+
+// Shell Utilities
+func shell(_ command: String) throws -> String {
+    let task = Process()
+    let pipe = Pipe()
+    task.standardOutput = pipe
+    task.standardError = pipe
+    task.arguments = ["-c", command]
+    task.executableURL = URL(fileURLWithPath: "/bin/zsh")
+    task.standardInput = nil
+    try task.run()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8)!
+    return output
+}
+
+// String Utilities
+func parseRegionFromApiKey(_ key: String) -> String? {
+    let range = NSRange(location: 0, length: key.utf16.count)
+    let regex = try? NSRegularExpression(pattern: "^.*?x")
+    if let regionMatch = regex?.firstMatch(in: key, options: [], range: range), regionMatch.numberOfRanges > 0 {
+        if let swiftRange = Range(regionMatch.range(at: 0), in: key) {
+            let regionString = String(key[swiftRange]).trimmingTrailingXs()
+            return "https://mobile-symbol-upload.\(regionString).nr-data.net"
+        }
+    }
+    return nil
+}
+
+extension String {
+   func trimmingTrailingXs() -> String {
+       guard let index = lastIndex(where: { String($0) != "x" }) else {
+            return self
+        }
+        return String(self[...index])
+    }
+}
+
+func getSizeAtURL(_ url: URL) -> UInt64? {
+    do {
+        let attrs = try fileManager.attributesOfItem(atPath: url.path)
+        guard let fileSize = attrs[.size] as? UInt64 else { 
+            print("Failed to acquire ")
+            return nil 
+        }
+        return fileSize
+    }
+    catch {
+        print("Error loading file attribute size. --failing")
+        return nil
+    }
+}

--- a/plugin/dsym-upload-tools/upload-react-native-sourcemap
+++ b/plugin/dsym-upload-tools/upload-react-native-sourcemap
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# 2026 New Relic
+# Shell wrapper script used to upload React Native source maps to New Relic.
+# upload-react-native-sourcemap
+
+INGEST_API_KEY=$1
+APP_TOKEN=$2
+
+# Check if credentials are provided and not placeholder values
+if [ -z "$INGEST_API_KEY" ] || [ -z "$APP_TOKEN" ] || \
+   [ "$INGEST_API_KEY" = "NEWRELIC_INGEST_KEY" ] || [ "$APP_TOKEN" = "NEWRELIC_APP_TOKEN" ] || \
+   [ "$INGEST_API_KEY" = "YOUR_INGEST_API_KEY" ] || [ "$APP_TOKEN" = "YOUR_APP_TOKEN" ]; then
+    echo "New Relic: Skipping source map upload - credentials not configured"
+    echo "New Relic: To enable source map uploads, set NEWRELIC_INGEST_KEY and NEWRELIC_APP_TOKEN environment variables"
+    echo "New Relic: See https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-react-native for setup instructions"
+    exit 0
+fi
+DEBUG_FLAG=${3:-''}
+
+echo "New Relic: Processing React Native source map and uploading to New Relic. (In background...)"
+echo "New Relic: For troubleshooting, see upload_sourcemap_results.log file in project root folder. Add --debug as third argument in Run Script for additional information."
+
+WORK_DIRECTORY=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+SCRIPT="$WORK_DIRECTORY/upload-react-native-sourcemap.swift"
+
+## Running with below command is useful for seeing output in Xcode,
+## but it will incur delays in the build process while the source map uploads.
+# /usr/bin/xcrun --sdk macosx swift "$SCRIPT" $INGEST_API_KEY $APP_TOKEN $DEBUG_FLAG
+
+/usr/bin/xcrun --sdk macosx swift "$SCRIPT" $INGEST_API_KEY $APP_TOKEN $DEBUG_FLAG > upload_sourcemap_results.log 2>&1 &

--- a/plugin/dsym-upload-tools/upload-react-native-sourcemap.swift
+++ b/plugin/dsym-upload-tools/upload-react-native-sourcemap.swift
@@ -1,0 +1,640 @@
+//
+//  upload-react-native-sourcemap.swift
+//  2026 New Relic
+//
+// Swift script used to upload React Native source maps to New Relic.
+// Intended to be run from a Xcode build phase.
+//
+// 1. In Xcode, select your project in the navigator, then click on the application target.
+// 2. Select the Build Phases tab in the settings editor.
+// 3. Click the + icon above Target Dependencies and choose New Run Script Build Phase.
+// 4. Add the following lines of code to the new phase AFTER "Bundle React Native code and images",
+//    replacing YOUR_INGEST_API_KEY and YOUR_APP_TOKEN with your actual keys:
+//
+// ```
+//  SCRIPT=`/usr/bin/find "${SRCROOT}" -name upload-react-native-sourcemap | head -n 1`
+//  /bin/sh "${SCRIPT}" "YOUR_INGEST_API_KEY" "YOUR_APP_TOKEN"
+// ```
+//
+// Where:
+//  - YOUR_INGEST_API_KEY: Get from https://one.newrelic.com/api-keys
+//  - YOUR_APP_TOKEN: Your New Relic Mobile App Token (same one used by the agent)
+//
+// Optional:
+//
+// Add "--debug" as third argument to enable debug logs in the output upload_sourcemap_results.log file.
+//
+// ```
+//  SCRIPT=`/usr/bin/find "${SRCROOT}" -name upload-react-native-sourcemap | head -n 1`
+//  /bin/sh "${SCRIPT}" "YOUR_INGEST_API_KEY" "YOUR_APP_TOKEN" --debug
+// ```
+//
+// Region:
+// The upload host is derived from the app token's region prefix:
+//   US (no prefix)  -> https://symbol-ingest-api.service.newrelic.com
+//   EU (eu01x...)   -> https://symbol-ingest-api.service.eu.newrelic.com
+//   JP (jp01x...)   -> https://symbol-ingest-api.service.jp.newrelic.com
+// Setting SOURCEMAP_UPLOAD_URL overrides the auto-detected host.
+//
+// Environment Variables (optional):
+// SOURCEMAP_UPLOAD_URL - Override the New Relic server hostname
+// SOURCEMAP_PATH - Override the default source map location (${DERIVED_FILE_DIR}/main.jsbundle.map)
+//
+// ============================================================================
+// START of Script upload-react-native-sourcemap.swift
+import Foundation
+
+let defaultURL = "https://symbol-ingest-api.service.newrelic.com"
+let fileManager = FileManager.default
+let environment = ProcessInfo.processInfo.environment
+// Set to true for additional debug info in the upload_sourcemap_results.log file.
+var debug = false
+
+var sourcemapEndpointPath = "v1/react-native/sourcemaps"
+var sourcemapUploadDataPostKey = "sourcemap"
+let telemetryDataHeader = "x-telemetry-data"
+
+// Maximum file size: 200MB
+let maxFileSizeBytes: UInt64 = 209715200
+
+enum SourceMapToolError: Error {
+    case sourceMapNotFound
+    case failedToUpload
+    case fileTooLarge
+    case invalidConfiguration
+}
+
+start()
+
+func start() {
+    print("New Relic: Starting React Native source map upload script...")
+
+    // Only run for Release builds
+    guard let configuration = environment["CONFIGURATION"], configuration == "Release" else {
+        print("New Relic: Skipping source map upload (not a Release build)")
+        exit(0)
+    }
+
+    // Skip simulator builds (unless testing)
+    let platformName = environment["EFFECTIVE_PLATFORM_NAME"]
+    let allowSimulator = environment["NEWRELIC_SOURCEMAP_ALLOW_SIMULATOR"] == "true"
+    if platformName == "-iphonesimulator" && !allowSimulator {
+        print("New Relic: Skipping source map upload for simulator build")
+        print("New Relic: Set NEWRELIC_SOURCEMAP_ALLOW_SIMULATOR=true to enable simulator uploads for testing")
+        exit(0)
+    }
+
+    // Check for disabled flag
+    if environment["NEWRELIC_SOURCEMAP_UPLOAD_DISABLED"] == "true" {
+        print("New Relic: Source map upload is disabled via NEWRELIC_SOURCEMAP_UPLOAD_DISABLED")
+        exit(0)
+    }
+
+    // Parse command line arguments
+    guard CommandLine.arguments.count > 2 else {
+        print("Invalid Usage: Ex: Swift: upload-react-native-sourcemap.swift $INGEST_API_KEY $APP_TOKEN [--debug]")
+        print("New Relic: Please provide both:")
+        print("  1. Ingest API Key (from https://one.newrelic.com/api-keys)")
+        print("  2. Mobile App Token (from your New Relic mobile app settings)")
+        exit(1)
+    }
+    let apiKey = CommandLine.arguments[1]
+    let appToken = CommandLine.arguments[2]
+
+    if CommandLine.arguments.count == 4 {
+        let debugFlag = CommandLine.arguments[3]
+        if debugFlag == "--debug" {
+            debug = true
+        }
+    }
+
+    // Configure Environment Variables
+    // SOURCEMAP_UPLOAD_URL (if set) takes precedence; otherwise derive from the app token's region prefix (EU/JP).
+    var url: String
+    if let override = environment["SOURCEMAP_UPLOAD_URL"] {
+        url = override
+    } else if let regionAwareURL = regionAwareURL(forAppToken: appToken) {
+        url = regionAwareURL
+        print("New Relic: Using region-aware URL: \(url)")
+    } else {
+        url = defaultURL
+    }
+    sourcemapEndpointPath = environment["NEWRELIC_SOURCEMAP_ENDPOINT"] ?? "v1/react-native/sourcemaps"
+
+    // Determine source map path
+    let derivedFileDir = environment["DERIVED_FILE_DIR"] ?? ""
+    let sourcemapPath = environment["SOURCEMAP_PATH"] ?? "\(derivedFileDir)/main.jsbundle.map"
+
+    if debug {
+        print("========== Configuration = \(configuration)")
+        print("========== Platform = \(platformName ?? "NOT FOUND")")
+        print("========== Source Map Path = \(sourcemapPath)")
+        print("========== URL = \(url)")
+        print("========== API Key = \(apiKey.prefix(10))...")
+    }
+
+    // Check if source map exists
+    guard fileManager.fileExists(atPath: sourcemapPath) else {
+        print("Error: Source map not found at: \(sourcemapPath)")
+        print("Make sure React Native bundling completed successfully and SOURCEMAP_OUTPUT is set.")
+        print("This script should run AFTER the 'Bundle React Native code and images' build phase.")
+        exit(1)
+    }
+
+    print("New Relic: Found source map at: \(sourcemapPath)")
+
+    // Check file size
+    var sourcemapFileSize: UInt64 = 0
+    do {
+        let attributes = try fileManager.attributesOfItem(atPath: sourcemapPath)
+        if let fileSize = attributes[.size] as? UInt64 {
+            sourcemapFileSize = fileSize
+            let fileSizeMB = Double(fileSize) / 1024.0 / 1024.0
+            print("New Relic: Source map size: \(String(format: "%.2f", fileSizeMB))MB")
+        }
+    } catch {
+        print("Warning: Could not determine file size: \(error)")
+    }
+
+    // Extract version info from Info.plist
+    guard let infoplistPath = environment["INFOPLIST_PATH"],
+          let builtProductsDir = environment["BUILT_PRODUCTS_DIR"] else {
+        print("Error: Could not find Info.plist path from environment")
+        exit(1)
+    }
+
+    let builtInfoPlistPath = "\(builtProductsDir)/\(infoplistPath)"
+
+    guard let infoPlist = NSDictionary(contentsOfFile: builtInfoPlistPath) else {
+        print("Error: Could not read Info.plist at: \(builtInfoPlistPath)")
+        exit(1)
+    }
+
+    guard let appVersion = infoPlist["CFBundleShortVersionString"] as? String else {
+        print("Error: Could not read CFBundleShortVersionString from Info.plist")
+        exit(1)
+    }
+
+    guard let buildNumber = infoPlist["CFBundleVersion"] as? String else {
+        print("Error: Could not read CFBundleVersion from Info.plist")
+        exit(1)
+    }
+
+    // jsBundleId is the same as appVersion (CFBundleShortVersionString)
+    let jsBundleId = appVersion
+
+    let sourcemapName = "main.jsbundle.map"
+
+    print("New Relic: Upload metadata:")
+    print("  App Version: \(appVersion)")
+    print("  JS Bundle ID: \(jsBundleId)")
+    print("  Source Map Name: \(sourcemapName)")
+    if debug {
+        print("  App Token: \(appToken.prefix(10))...")
+    }
+
+    // Upload source map
+    let uploadURL = "\(url)/\(sourcemapEndpointPath)"
+
+    // If the source map exceeds the 200MB limit, skip the upload entirely and send
+    // telemetry metadata instead, rather than failing the build. Mirrors the Android
+    // agent's oversized-source-map handling (ReactNativeSourceMap.sendTelemetryOnly).
+    if sourcemapFileSize > maxFileSizeBytes {
+        sendTelemetryOnly(
+            apiKey: apiKey,
+            appToken: appToken,
+            url: uploadURL,
+            jsBundleId: jsBundleId,
+            appVersion: appVersion,
+            sourcemapName: sourcemapName,
+            sourcemapSize: sourcemapFileSize
+        )
+        exit(0)
+    }
+
+    print("New Relic: Uploading to: \(uploadURL)")
+
+    do {
+        try uploadSourceMap(
+            apiKey: apiKey,
+            appToken: appToken,
+            url: uploadURL,
+            sourcemapPath: sourcemapPath,
+            jsBundleId: jsBundleId,
+            appVersion: appVersion,
+            sourcemapName: sourcemapName
+        )
+        print("New Relic: ✓ Source map uploaded successfully!")
+        exit(0)
+    } catch {
+        print("Error: Source map upload failed: \(error)")
+        exit(1)
+    }
+}
+
+// MARK: - Helper Functions
+
+func uploadSourceMap(
+    apiKey: String,
+    appToken: String,
+    url: String,
+    sourcemapPath: String,
+    jsBundleId: String,
+    appVersion: String,
+    sourcemapName: String
+) throws {
+
+    guard let uploadURL = URL(string: url) else {
+        throw SourceMapToolError.invalidConfiguration
+    }
+
+    // Create multipart form data
+    let boundary = "Boundary-\(UUID().uuidString)"
+    var request = URLRequest(url: uploadURL)
+    request.httpMethod = "POST"
+    request.setValue(apiKey, forHTTPHeaderField: "Api-Key")
+    request.setValue(appToken, forHTTPHeaderField: "X-APP-LICENSE-KEY")
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+    var body = Data()
+
+    // Add text fields
+    let textFields = [
+        "jsBundleId": jsBundleId,
+        "appVersion": appVersion,
+        "sourcemapName": sourcemapName
+    ]
+
+    for (key, value) in textFields {
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".data(using: .utf8)!)
+        body.append("\(value)\r\n".data(using: .utf8)!)
+    }
+
+    // Add source map file
+    guard var fileData = try? Data(contentsOf: URL(fileURLWithPath: sourcemapPath)) else {
+        throw SourceMapToolError.sourceMapNotFound
+    }
+
+    let maxSizeBytes = 200 * 1024 * 1024  // 200MB
+    let compressionThreshold = 50 * 1024 * 1024  // Compress if > 50MB
+    let originalSizeMB = Double(fileData.count) / (1024 * 1024)
+    var uploadFilename = sourcemapName
+    var contentType = "application/json"
+
+    // Check if compression is needed
+    if fileData.count > compressionThreshold {
+        print("Source map size: \(String(format: "%.2f", originalSizeMB))MB")
+        print("Compressing source map for upload...")
+
+        // Create temporary zip file
+        let tempDir = NSTemporaryDirectory()
+        let zipPath = (tempDir as NSString).appendingPathComponent("sourcemap.zip")
+        let sourceMapFilename = (sourcemapPath as NSString).lastPathComponent
+
+        // Use ditto command to create zip (available on macOS)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        process.arguments = ["-c", "-k", "--sequesterRsrc", "--keepParent", sourcemapPath, zipPath]
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+
+            if process.terminationStatus == 0 {
+                // Read compressed file
+                if let compressedData = try? Data(contentsOf: URL(fileURLWithPath: zipPath)) {
+                    let compressedSizeMB = Double(compressedData.count) / (1024 * 1024)
+                    let compressionRatio = (1.0 - Double(compressedData.count) / Double(fileData.count)) * 100
+
+                    print("Compressed size: \(String(format: "%.2f", compressedSizeMB))MB (\(String(format: "%.1f", compressionRatio))% reduction)")
+
+                    // Check if compressed file is still too large
+                    if compressedData.count > maxSizeBytes {
+                        print("Error: Compressed source map is still too large (\(String(format: "%.2f", compressedSizeMB))MB)")
+                        print("Maximum allowed size is 200MB")
+                        print("Consider:")
+                        print("  • Enable JavaScript minification")
+                        print("  • Use code splitting or dynamic imports")
+                        print("  • Switch to Hermes engine")
+                        try? FileManager.default.removeItem(atPath: zipPath)
+                        throw SourceMapToolError.failedToUpload
+                    }
+
+                    fileData = compressedData
+                    uploadFilename = "sourcemap.zip"
+                    contentType = "application/zip"
+
+                    // Clean up temp file
+                    try? FileManager.default.removeItem(atPath: zipPath)
+                } else {
+                    print("Warning: Failed to read compressed file, uploading uncompressed")
+                }
+            } else {
+                print("Warning: Compression failed, uploading uncompressed")
+            }
+        } catch {
+            print("Warning: Could not compress file (\(error)), uploading uncompressed")
+        }
+    }
+
+    // Final size check for uncompressed files
+    if fileData.count > maxSizeBytes {
+        let sizeMB = Double(fileData.count) / (1024 * 1024)
+        print("Error: Source map file is too large (\(String(format: "%.2f", sizeMB))MB)")
+        print("Maximum allowed size is 200MB")
+        print("Consider enabling minification or code splitting in your React Native build")
+        throw SourceMapToolError.failedToUpload
+    }
+
+    body.append("--\(boundary)\r\n".data(using: .utf8)!)
+    body.append("Content-Disposition: form-data; name=\"sourcemap\"; filename=\"\(uploadFilename)\"\r\n".data(using: .utf8)!)
+    body.append("Content-Type: \(contentType)\r\n\r\n".data(using: .utf8)!)
+    body.append(fileData)
+    body.append("\r\n".data(using: .utf8)!)
+    body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+
+    request.httpBody = body
+
+    if debug {
+        print("Request URL: \(uploadURL)")
+        print("Request body size: \(body.count) bytes")
+    }
+
+    // Perform synchronous upload
+    let semaphore = DispatchSemaphore(value: 0)
+    var uploadError: Error?
+    var httpStatusCode: Int = 0
+
+    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        defer { semaphore.signal() }
+
+        if let error = error {
+            uploadError = error
+            return
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            uploadError = SourceMapToolError.failedToUpload
+            return
+        }
+
+        httpStatusCode = httpResponse.statusCode
+
+        if debug {
+            print("Response status code: \(httpStatusCode)")
+            if let data = data, let responseString = String(data: data, encoding: .utf8) {
+                print("Response body: \(responseString)")
+            }
+        }
+
+        // Parse error response if available
+        var errorMessage: String?
+        if let data = data,
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            errorMessage = json["message"] as? String ?? json["errorMessage"] as? String
+        }
+
+        // 409 means a source map for this jsBundleId has already been stored -- this is
+        // expected/harmless (e.g. a rebuild without a version bump), not a failure.
+        // Matches the Android agent's HTTP_CONFLICT handling.
+        if httpStatusCode == 409 {
+            print("New Relic: A source map for this build (jsBundleId: \(jsBundleId)) has already been stored.")
+            return
+        }
+
+        guard (200...299).contains(httpStatusCode) else {
+            print("Error: Source map upload failed (HTTP \(httpStatusCode))")
+
+            switch httpStatusCode {
+            case 400:
+                print("Bad Request - Validation failed")
+                if let error = errorMessage {
+                    print("  \(error)")
+                }
+                print("Common causes:")
+                print("  • Source map version must be 3")
+                print("  • Missing required fields (jsBundleId, appVersion, sourcemapName)")
+                print("  • Invalid JSON format")
+                print("  • ZIP file issues (no valid files, multiple files, or invalid extension)")
+
+            case 401:
+                print("Unauthorized - API key and app token mismatch")
+                if let error = errorMessage {
+                    print("  \(error)")
+                }
+                print("The API key is valid, but the app token belongs to a different account.")
+                print("Ensure both are from the same New Relic account.")
+
+            case 403:
+                print("Forbidden - API key lacks required capability")
+                if let error = errorMessage {
+                    print("  \(error)")
+                }
+                print("Check your New Relic Ingest API Key at https://one.newrelic.com/api-keys")
+
+            case 404:
+                print("Not Found - Invalid app token")
+                if let error = errorMessage {
+                    print("  \(error)")
+                }
+                print("The X-APP-LICENSE-KEY (app token) doesn't exist.")
+                print("Verify your app token in the New Relic mobile app settings.")
+
+            case 413:
+                print("Payload Too Large - File exceeds size limit")
+                if let error = errorMessage {
+                    print("  \(error)")
+                }
+                print("The source map file exceeds 200MB (zipped or unzipped).")
+                print("Consider:")
+                print("  • Enable JavaScript minification")
+                print("  • Use code splitting or dynamic imports")
+                print("  • Switch to Hermes engine (produces smaller bundles)")
+
+            case 500...599:
+                print("Internal Server Error - Server-side issue")
+                if let error = errorMessage {
+                    print("  \(error)")
+                }
+                print("An unexpected error occurred on the server.")
+                print("Check upload_sourcemap_results.log and try again.")
+
+            default:
+                if let error = errorMessage {
+                    print("  \(error)")
+                }
+            }
+
+            // Always print full response body in debug mode
+            if let data = data, let responseString = String(data: data, encoding: .utf8) {
+                if debug {
+                    print("Full response body: \(responseString)")
+                }
+            }
+
+            uploadError = SourceMapToolError.failedToUpload
+            return
+        }
+
+        // Success - Parse and display metadata
+        if httpStatusCode == 201, let data = data,
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let metadata = json["sourcemapMetaData"] as? [String: Any] {
+            print("✅ Source map uploaded successfully!")
+            if let entityGuid = metadata["entityGuid"] as? String {
+                print("  Entity GUID: \(entityGuid)")
+            }
+            if let accountId = metadata["accountId"] {
+                print("  Account ID: \(accountId)")
+            }
+            if let appId = metadata["applicationId"] {
+                print("  Application ID: \(appId)")
+            }
+            if let jsBundleId = metadata["JSBundleId"] as? String {
+                print("  JS Bundle ID: \(jsBundleId)")
+            }
+            if let appVersion = metadata["appVersion"] as? String {
+                print("  App Version: \(appVersion)")
+            }
+            if let createdAt = metadata["createdAt"] as? String {
+                print("  Created At: \(createdAt)")
+            }
+        } else {
+            print("✅ Source map uploaded successfully (HTTP \(httpStatusCode))")
+        }
+    }
+
+    task.resume()
+    semaphore.wait()
+
+    if let error = uploadError {
+        throw error
+    }
+}
+
+// Sends telemetry metadata instead of the actual source map when the map exceeds the
+// 200MB limit. No file body is included -- the x-telemetry-data header (Base64-encoded
+// JSON) is the payload. A non-2xx response is expected (there's no file for the server
+// to validate) and is logged, not treated as a failure -- this function never throws,
+// mirroring the Android agent's non-fatal telemetry send (ReactNativeSourceMap.sendTelemetryOnly).
+func sendTelemetryOnly(
+    apiKey: String,
+    appToken: String,
+    url: String,
+    jsBundleId: String,
+    appVersion: String,
+    sourcemapName: String,
+    sourcemapSize: UInt64
+) {
+    print("New Relic: Source map exceeds 200MB limit. Sending telemetry data instead of the file.")
+
+    let bundlePath = "\(environment["BUILT_PRODUCTS_DIR"] ?? "")/main.jsbundle"
+    var bundleSize: UInt64 = 0
+    if let attributes = try? fileManager.attributesOfItem(atPath: bundlePath),
+       let size = attributes[.size] as? UInt64 {
+        bundleSize = size
+    }
+    let bundleName = sourcemapName.replacingOccurrences(of: ".map", with: "")
+
+    let telemetryJSON = "{\"bundler\":\"metro\",\"bundles\":[{\"name\":\"\(bundleName)\",\"size\":\(bundleSize)}],"
+        + "\"sourcemaps\":[{\"name\":\"\(sourcemapName)\",\"size\":\(sourcemapSize)}]}"
+    let encodedTelemetry = Data(telemetryJSON.utf8).base64EncodedString()
+
+    if debug {
+        print("========== Telemetry JSON = \(telemetryJSON)")
+    }
+
+    guard let telemetryURL = URL(string: url) else {
+        print("Warning: Could not build telemetry request URL (non-critical).")
+        print("New Relic: JavaScript errors for this build will not be symbolicated.")
+        return
+    }
+
+    let boundary = "Boundary-\(UUID().uuidString)"
+    var request = URLRequest(url: telemetryURL)
+    request.httpMethod = "POST"
+    request.setValue(apiKey, forHTTPHeaderField: "Api-Key")
+    request.setValue(appToken, forHTTPHeaderField: "X-APP-LICENSE-KEY")
+    request.setValue(encodedTelemetry, forHTTPHeaderField: telemetryDataHeader)
+    request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+    var body = Data()
+    let textFields = [
+        "jsBundleId": jsBundleId,
+        "appVersion": appVersion,
+        "sourcemapName": sourcemapName
+    ]
+    for (key, value) in textFields {
+        body.append("--\(boundary)\r\n")
+        body.append("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n")
+        body.append("\(value)\r\n")
+    }
+    body.append("--\(boundary)--\r\n")
+    request.httpBody = body
+
+    let semaphore = DispatchSemaphore(value: 0)
+    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        defer { semaphore.signal() }
+
+        if let error = error {
+            print("Note: Telemetry send encountered an error (non-critical): \(error.localizedDescription)")
+            return
+        }
+        guard let httpResponse = response as? HTTPURLResponse else { return }
+        // A non-2xx response is expected here since no source map file is attached --
+        // the telemetry header is the payload, not the response status.
+        print("New Relic: Telemetry data sent (server returned \(httpResponse.statusCode)).")
+        if debug, let data = data, let responseString = String(data: data, encoding: .utf8) {
+            print("Response body: \(responseString)")
+        }
+    }
+    task.resume()
+    semaphore.wait()
+
+    print("New Relic: New Relic currently supports source map files up to 200MB. The source map for this build exceeds that limit.")
+    print("New Relic: JavaScript errors for this build will not be symbolicated.")
+}
+
+// MARK: - Region Parsing
+
+// Parses a region prefix (e.g. "eu01", "jp01") from a New Relic app token.
+// The token format is "<region>x...x<key>". Returns nil if no region prefix is present (US).
+func parseRegionFromAppToken(_ token: String) -> String? {
+    let range = NSRange(location: 0, length: token.utf16.count)
+    guard let regex = try? NSRegularExpression(pattern: "^.+?x"),
+          let match = regex.firstMatch(in: token, options: [], range: range),
+          let swiftRange = Range(match.range, in: token) else {
+        return nil
+    }
+    let raw = String(token[swiftRange])
+    guard let lastNonX = raw.lastIndex(where: { $0 != "x" }) else {
+        return nil
+    }
+    let trimmed = String(raw[...lastNonX])
+    return trimmed.isEmpty ? nil : trimmed
+}
+
+// Maps a parsed region prefix to the symbol-ingest-api host.
+// e.g. "eu01" -> https://symbol-ingest-api.service.eu.newrelic.com
+//      "jp01" -> https://symbol-ingest-api.service.jp.newrelic.com
+// The region family is the prefix stripped of trailing digits (eu01 -> eu).
+func regionAwareURL(forAppToken token: String) -> String? {
+    guard let region = parseRegionFromAppToken(token) else { return nil }
+    var regionFamily = region.lowercased()
+    while let last = regionFamily.last, last.isNumber {
+        regionFamily.removeLast()
+    }
+    guard !regionFamily.isEmpty else { return nil }
+    return "https://symbol-ingest-api.service.\(regionFamily).newrelic.com"
+}
+
+// MARK: - Extensions
+
+extension Data {
+    mutating func append(_ string: String) {
+        if let data = string.data(using: .utf8) {
+            append(data)
+        }
+    }
+}

--- a/plugin/src/android/index.ts
+++ b/plugin/src/android/index.ts
@@ -6,6 +6,7 @@
 import { withApplyNewRelicPlugin } from './applyPlugin';
 import { withBuildscriptDependency } from './buildscriptDependency';
 import { withNetworkAcessPermission} from './permissions'
+import { withNewRelicMapUploadProperties, NewRelicPluginProps, defaultApiKeyEnvName, defaultAppTokenEnvName } from './mapUploadProperties';
 
 
-export { withBuildscriptDependency, withApplyNewRelicPlugin,withNetworkAcessPermission };
+export { withBuildscriptDependency, withApplyNewRelicPlugin, withNetworkAcessPermission, withNewRelicMapUploadProperties, NewRelicPluginProps, defaultApiKeyEnvName, defaultAppTokenEnvName };

--- a/plugin/src/android/mapUploadProperties.ts
+++ b/plugin/src/android/mapUploadProperties.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
+
+export const defaultApiKeyEnvName = 'NEWRELIC_USER_API_KEY';
+export const defaultAppTokenEnvName = 'NEWRELIC_ANDROID_APP_TOKEN';
+
+export type NewRelicPluginProps = {
+  android?: {
+    /**
+     * Name of the environment variable containing the New Relic User API key.
+     * Written to `newrelic.properties` as `com.newrelic.api_key`.
+     * Defaults to `NEWRELIC_USER_API_KEY`.
+     */
+    apiKeyEnvName?: string;
+    /**
+     * Name of the environment variable containing the Android application token
+     * (the same token passed to `NewRelic.startAgent()`). Written to
+     * `newrelic.properties` as `com.newrelic.application_token`.
+     * Defaults to `NEWRELIC_ANDROID_APP_TOKEN`.
+     */
+    appTokenEnvName?: string;
+  };
+};
+
+/**
+ * Write `android/app/newrelic.properties` with the New Relic User API key and Android
+ * application token sourced from environment variables, so the agent's
+ * `newrelicMapUploadRelease` and `newrelicReactNativeSourceMapUploadRelease` Gradle
+ * tasks can automatically upload the ProGuard/R8 mapping file and React Native source
+ * map after release builds, without committing credentials to the repo.
+ *
+ * Property names (`com.newrelic.api_key` / `com.newrelic.application_token`) match what
+ * the native `agent-gradle-plugin` reads from this file.
+ */
+export const withNewRelicMapUploadProperties: ConfigPlugin<NewRelicPluginProps> = (
+  config,
+  props = {},
+) => {
+  return withDangerousMod(config, [
+    'android',
+    config => {
+      const apiKeyEnvName = props.android?.apiKeyEnvName ?? defaultApiKeyEnvName;
+      const appTokenEnvName = props.android?.appTokenEnvName ?? defaultAppTokenEnvName;
+      const apiKey = process.env[apiKeyEnvName];
+      const appToken = process.env[appTokenEnvName];
+
+      const lines: string[] = [];
+      if (apiKey) {
+        lines.push(`com.newrelic.api_key=${apiKey}`);
+      }
+      if (appToken) {
+        lines.push(`com.newrelic.application_token=${appToken}`);
+      }
+
+      if (lines.length === 0) {
+        return config;
+      }
+
+      const propertiesPath = path.join(
+        config.modRequest.platformProjectRoot,
+        'app',
+        'newrelic.properties',
+      );
+      fs.writeFileSync(propertiesPath, lines.join('\n') + '\n');
+
+      return config;
+    },
+  ]);
+};

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -5,15 +5,26 @@
 
 import { ConfigPlugin, withPlugins, createRunOncePlugin } from '@expo/config-plugins';
 
-import { withApplyNewRelicPlugin, withBuildscriptDependency, withNetworkAcessPermission } from './android';
+import {
+  withApplyNewRelicPlugin,
+  withBuildscriptDependency,
+  withNetworkAcessPermission,
+  withNewRelicMapUploadProperties,
+  NewRelicPluginProps,
+} from './android';
 
 const projectPackage = require('newrelic-react-native-agent/package.json');
 
 /**
  * A config plugin for configuring `newrelic-react-native-agent`
  */
-const withNewRelicRNAgent: ConfigPlugin = config => {
-  return withPlugins(config, [withBuildscriptDependency, withApplyNewRelicPlugin,withNetworkAcessPermission]);
+const withNewRelicRNAgent: ConfigPlugin<NewRelicPluginProps | void> = (config, props) => {
+  return withPlugins(config, [
+    withBuildscriptDependency,
+    withApplyNewRelicPlugin,
+    withNetworkAcessPermission,
+    [withNewRelicMapUploadProperties, props ?? {}],
+  ]);
 };
 
-export default createRunOncePlugin(withNewRelicRNAgent,projectPackage.name, projectPackage.version);
+export default createRunOncePlugin(withNewRelicRNAgent, projectPackage.name, projectPackage.version);

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -12,18 +12,27 @@ import {
   withNewRelicMapUploadProperties,
   NewRelicPluginProps,
 } from './android';
+import {
+  withNewRelicDsymUploadFiles,
+  withNewRelicDsymUploadBuildPhase,
+  NewRelicIosPluginProps,
+} from './ios';
 
 const projectPackage = require('newrelic-react-native-agent/package.json');
+
+type CombinedNewRelicPluginProps = NewRelicPluginProps & NewRelicIosPluginProps;
 
 /**
  * A config plugin for configuring `newrelic-react-native-agent`
  */
-const withNewRelicRNAgent: ConfigPlugin<NewRelicPluginProps | void> = (config, props) => {
+const withNewRelicRNAgent: ConfigPlugin<CombinedNewRelicPluginProps | void> = (config, props) => {
   return withPlugins(config, [
     withBuildscriptDependency,
     withApplyNewRelicPlugin,
     withNetworkAcessPermission,
     [withNewRelicMapUploadProperties, props ?? {}],
+    withNewRelicDsymUploadFiles,
+    [withNewRelicDsymUploadBuildPhase, props ?? {}],
   ]);
 };
 

--- a/plugin/src/ios/dsymUpload.ts
+++ b/plugin/src/ios/dsymUpload.ts
@@ -119,13 +119,19 @@ export const withNewRelicDsymUploadBuildPhase: ConfigPlugin<NewRelicIosPluginPro
 
     const existingPhase = project.buildPhaseObject('PBXShellScriptBuildPhase', BUILD_PHASE_NAME);
     if (!existingPhase) {
-      project.addBuildPhase(
+      const { buildPhase } = project.addBuildPhase(
         [],
         'PBXShellScriptBuildPhase',
         BUILD_PHASE_NAME,
         project.getFirstTarget().uuid,
         { shellPath: '/bin/sh', shellScript: buildUploadScript(appTokenEnvName, apiKeyEnvName) },
       );
+      // Without declared inputs/outputs, Xcode's new build system warns that the script
+      // "has ambiguous dependencies causing it to run on every build". We DO want it to
+      // run on every Release build, so explicitly mark it always-out-of-date (equivalent
+      // to unchecking "Based on dependency analysis" in Xcode) rather than declaring
+      // outputPaths, which could make a later build with unchanged inputs skip it.
+      buildPhase.alwaysOutOfDate = 1;
     }
 
     return config;

--- a/plugin/src/ios/dsymUpload.ts
+++ b/plugin/src/ios/dsymUpload.ts
@@ -64,7 +64,7 @@ function unwrapShellScript(raw: string): string {
 }
 
 function wrapShellScript(text: string): string {
-  return '"' + text.replace(/"/g, '\\"').replace(/\n/g, '\\n') + '"';
+  return '"' + text.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n') + '"';
 }
 
 function buildUploadScript(appTokenEnvName: string, apiKeyEnvName: string): string {

--- a/plugin/src/ios/dsymUpload.ts
+++ b/plugin/src/ios/dsymUpload.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { ConfigPlugin, withDangerousMod, withXcodeProject } from '@expo/config-plugins';
+
+export const defaultIosAppTokenEnvName = 'NEWRELIC_IOS_APP_TOKEN';
+export const defaultIosApiKeyEnvName = 'NEWRELIC_USER_API_KEY';
+
+export type NewRelicIosPluginProps = {
+  ios?: {
+    /**
+     * Name of the environment variable containing the iOS application token (the same
+     * token passed to `NewRelic.startAgent()` on iOS). Used by both the dSYM upload and
+     * the React Native source map upload build phase scripts.
+     * Defaults to `NEWRELIC_IOS_APP_TOKEN`.
+     */
+    appTokenEnvName?: string;
+    /**
+     * Name of the environment variable containing the New Relic User/Ingest API key.
+     * Only used by the React Native source map upload script.
+     * Defaults to `NEWRELIC_USER_API_KEY` (shared with the Android default).
+     */
+    apiKeyEnvName?: string;
+  };
+};
+
+const VENDORED_TOOLS_DIR = path.join(__dirname, '..', '..', 'dsym-upload-tools');
+const TOOLS_SUBDIR_NAME = 'dsym-upload-tools';
+const BUILD_PHASE_NAME = 'Upload dSYMs and Source Maps to New Relic';
+const BUNDLE_PHASE_NAME = 'Bundle React Native code and images';
+const SOURCEMAP_FILE_EXPORT_LINE = 'export SOURCEMAP_FILE="$DERIVED_FILE_DIR/main.jsbundle.map"';
+
+/**
+ * Copy the vendored `dsym-upload-tools` scripts into `ios/dsym-upload-tools`, since that
+ * directory is regenerated on every prebuild (locally and on EAS Build).
+ */
+export const withNewRelicDsymUploadFiles: ConfigPlugin = config => {
+  return withDangerousMod(config, [
+    'ios',
+    config => {
+      const destDir = path.join(config.modRequest.platformProjectRoot, TOOLS_SUBDIR_NAME);
+      fs.mkdirSync(destDir, { recursive: true });
+
+      for (const file of fs.readdirSync(VENDORED_TOOLS_DIR)) {
+        const srcPath = path.join(VENDORED_TOOLS_DIR, file);
+        const destPath = path.join(destDir, file);
+        fs.copyFileSync(srcPath, destPath);
+        fs.chmodSync(destPath, fs.statSync(srcPath).mode);
+      }
+
+      return config;
+    },
+  ]);
+};
+
+function unwrapShellScript(raw: string): string {
+  const trimmed = raw.startsWith('"') && raw.endsWith('"') ? raw.slice(1, -1) : raw;
+  return trimmed.replace(/\\"/g, '"').replace(/\\n/g, '\n');
+}
+
+function wrapShellScript(text: string): string {
+  return '"' + text.replace(/"/g, '\\"').replace(/\n/g, '\\n') + '"';
+}
+
+function buildUploadScript(appTokenEnvName: string, apiKeyEnvName: string): string {
+  return [
+    'ARTIFACT_DIR="${BUILD_DIR%Build/*}"',
+    '',
+    `if [ -n "$${appTokenEnvName}" ]; then`,
+    '  DSYM_SCRIPT=$(/usr/bin/find "${SRCROOT}" "${ARTIFACT_DIR}" -type f -name run-symbol-tool | head -n 1)',
+    '  if [ -n "$DSYM_SCRIPT" ]; then',
+    `    /bin/sh "$DSYM_SCRIPT" "$${appTokenEnvName}"`,
+    '  fi',
+    'else',
+    `  echo "New Relic: ${appTokenEnvName} not set, skipping dSYM upload"`,
+    'fi',
+    '',
+    `if [ -n "$${apiKeyEnvName}" ] && [ -n "$${appTokenEnvName}" ]; then`,
+    '  SOURCEMAP_SCRIPT=$(/usr/bin/find "${SRCROOT}" "${ARTIFACT_DIR}" -type f -name upload-react-native-sourcemap | head -n 1)',
+    '  if [ -n "$SOURCEMAP_SCRIPT" ]; then',
+    `    /bin/sh "$SOURCEMAP_SCRIPT" "$${apiKeyEnvName}" "$${appTokenEnvName}"`,
+    '  fi',
+    'else',
+    `  echo "New Relic: ${apiKeyEnvName} or ${appTokenEnvName} not set, skipping source map upload"`,
+    'fi',
+    '',
+    'exit 0',
+  ].join('\n');
+}
+
+/**
+ * Add a Run Script build phase (after "Bundle React Native code and images") that invokes
+ * the vendored dSYM and React Native source map upload scripts, and ensure the bundle
+ * phase exports SOURCEMAP_FILE so a source map actually gets generated for the script to
+ * find. Both additions are idempotent across repeated prebuilds.
+ */
+export const withNewRelicDsymUploadBuildPhase: ConfigPlugin<NewRelicIosPluginProps> = (
+  config,
+  props = {},
+) => {
+  const appTokenEnvName = props.ios?.appTokenEnvName ?? defaultIosAppTokenEnvName;
+  const apiKeyEnvName = props.ios?.apiKeyEnvName ?? defaultIosApiKeyEnvName;
+
+  return withXcodeProject(config, config => {
+    const project = config.modResults;
+
+    const bundlePhase = project.buildPhaseObject('PBXShellScriptBuildPhase', BUNDLE_PHASE_NAME);
+    if (bundlePhase) {
+      const script = unwrapShellScript(bundlePhase.shellScript);
+      if (!script.includes('SOURCEMAP_FILE=')) {
+        bundlePhase.shellScript = wrapShellScript(`${SOURCEMAP_FILE_EXPORT_LINE}\n${script}`);
+      }
+    }
+
+    const existingPhase = project.buildPhaseObject('PBXShellScriptBuildPhase', BUILD_PHASE_NAME);
+    if (!existingPhase) {
+      project.addBuildPhase(
+        [],
+        'PBXShellScriptBuildPhase',
+        BUILD_PHASE_NAME,
+        project.getFirstTarget().uuid,
+        { shellPath: '/bin/sh', shellScript: buildUploadScript(appTokenEnvName, apiKeyEnvName) },
+      );
+    }
+
+    return config;
+  });
+};

--- a/plugin/src/ios/index.ts
+++ b/plugin/src/ios/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  withNewRelicDsymUploadFiles,
+  withNewRelicDsymUploadBuildPhase,
+  NewRelicIosPluginProps,
+  defaultIosAppTokenEnvName,
+  defaultIosApiKeyEnvName,
+} from './dsymUpload';
+
+export {
+  withNewRelicDsymUploadFiles,
+  withNewRelicDsymUploadBuildPhase,
+  NewRelicIosPluginProps,
+  defaultIosAppTokenEnvName,
+  defaultIosApiKeyEnvName,
+};


### PR DESCRIPTION
## What & Why

Expo's Continuous Native Generation (CNG) regenerates `android/` and `ios/` from scratch on every `expo prebuild` (locally and on EAS Build), so any manually-added `newrelic.properties` file or Xcode Run Script build phase gets wiped out. This adds first-class Expo config-plugin support so the New Relic mapping-file / dSYM / source-map upload steps survive prebuild, with credentials sourced from environment variables (never hardcoded into git-tracked files) and documented for both EAS and local builds.

## Changes

- **Android**: the config plugin writes `android/app/newrelic.properties` from `NEWRELIC_USER_API_KEY` / `NEWRELIC_ANDROID_APP_TOKEN` (customizable env var names via plugin props), enabling the `newrelicMapUploadRelease` and `newrelicReactNativeSourceMapUploadRelease` Gradle tasks.
- **iOS**: the config plugin vendors the `dsym-upload-tools` scripts (from `newrelic-ios-agent`) into `ios/dsym-upload-tools/`, injects a "Upload dSYMs and Source Maps to New Relic" Run Script build phase (marked `alwaysOutOfDate`, matching the pattern CocoaPods' own generated phases use, to avoid Xcode's "ambiguous dependencies" warning while still running every Release build), and ensures `SOURCEMAP_FILE` is exported from the bundle phase so a source map actually gets generated for the script to find.
- Both mods are idempotent across repeated prebuilds.
- Fixed a pre-existing doc bug in `guides/react-native-javascript-error-reporting.md`: corrected the `newrelic.properties` keys (`com.newrelic.api_key` / `com.newrelic.application_token`, not the `apiKey=` shorthand previously documented), and removed a false claim that the build-time Gradle task can see the JS-side `NewRelic.startAgent()` token.
- README updated with setup instructions for both platforms, including an explicit warning that EAS's `secret`-visibility environment variables are never exposed to build scripts (use `sensitive` or `plaintext` instead) — a real pitfall hit during verification.

## Test plan

- Verified via multiple real `eas build` runs (local and cloud, Android + iOS) with real environment variables registered in EAS.
- **Android**: clean local `eas build --platform android --profile preview --local` — confirmed `newrelicMapUploadRelease` and `newrelicReactNativeSourceMapUploadRelease` both executed successfully (found real mapping/source-map files, no missing-config warnings), `BUILD SUCCESSFUL`.
- **iOS**: real cloud `eas build --platform ios --profile preview`, twice — first run confirmed graceful skip messaging when tokens aren't set ("NEWRELIC_IOS_APP_TOKEN not set, skipping..."), second run (with all 3 env vars registered) confirmed both `run-symbol-tool` and `upload-react-native-sourcemap` were actually invoked ("Processing dSYMs/source map and uploading to New Relic"), `BUILD SUCCEEDED`.
- Verified idempotency of both plugin mods across repeated `expo prebuild --clean` runs.
- `npx tsc --noEmit` clean; full Jest suite (10 suites / 95 tests) passing.